### PR TITLE
NPC Trait Updates

### DIFF
--- a/paper/pom.xml
+++ b/paper/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>net.citizensnpcs</groupId>
             <artifactId>citizens-main</artifactId>
-            <version>2.0.42-SNAPSHOT</version>
+            <version>2.0.43-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySneaking.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySneaking.java
@@ -1,6 +1,5 @@
 package com.denizenscript.denizen.paper.properties;
 
-import com.denizenscript.denizen.npc.traits.SneakingTrait;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.properties.entity.EntityProperty;
 import com.denizenscript.denizencore.objects.Mechanism;
@@ -42,18 +41,15 @@ public class EntitySneaking extends EntityProperty<ElementTag> {
         }
         boolean sneaking = value.asBoolean();
         getEntity().setSneaking(sneaking);
-        if (object.isCitizensNPC()) {
-            NPC npc = object.getDenizenNPC().getCitizen();
-            if (sneaking) {
-                npc.getOrAddTrait(SneakTrait.class).setSneaking(true);
-            }
-            else if (npc.hasTrait(SneakTrait.class)) {
-                npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
-            }
-            else if (npc.hasTrait(SneakingTrait.class)) { // backsupport
-                npc.getTraitNullable(SneakingTrait.class).stand();
-                npc.removeTrait(SneakingTrait.class);
-            }
+        if (!object.isCitizensNPC()) {
+            return;
+        }
+        NPC npc = object.getDenizenNPC().getCitizen();
+        if (sneaking) {
+            npc.getOrAddTrait(SneakTrait.class).setSneaking(true);
+        }
+        else if (npc.hasTrait(SneakTrait.class)) {
+            npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
         }
     }
 

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySneaking.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySneaking.java
@@ -6,6 +6,7 @@ import com.denizenscript.denizen.objects.properties.entity.EntityProperty;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.trait.SneakTrait;
 
 public class EntitySneaking extends EntityProperty<ElementTag> {
 
@@ -36,18 +37,23 @@ public class EntitySneaking extends EntityProperty<ElementTag> {
 
     @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (mechanism.requireBoolean()) {
-            boolean sneaking = value.asBoolean();
-            getEntity().setSneaking(sneaking);
-            if (object.isCitizensNPC()) {
-                NPC npc = object.getDenizenNPC().getCitizen();
-                if (sneaking) {
-                    npc.getOrAddTrait(SneakingTrait.class).sneak();
-                }
-                else if (npc.hasTrait(SneakingTrait.class)) {
-                    npc.getTraitNullable(SneakingTrait.class).stand();
-                    npc.removeTrait(SneakingTrait.class);
-                }
+        if (!mechanism.requireBoolean()) {
+            return;
+        }
+        boolean sneaking = value.asBoolean();
+        getEntity().setSneaking(sneaking);
+        if (object.isCitizensNPC()) {
+            NPC npc = object.getDenizenNPC().getCitizen();
+            if (sneaking) {
+                npc.getOrAddTrait(SneakTrait.class).setSneaking(true);
+            }
+            else if (npc.hasTrait(SneakTrait.class)) {
+                npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
+                npc.removeTrait(SneakTrait.class);
+            }
+            else if (npc.hasTrait(SneakingTrait.class)) { // backsupport
+                npc.getTraitNullable(SneakingTrait.class).stand();
+                npc.removeTrait(SneakingTrait.class);
             }
         }
     }

--- a/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySneaking.java
+++ b/paper/src/main/java/com/denizenscript/denizen/paper/properties/EntitySneaking.java
@@ -49,7 +49,6 @@ public class EntitySneaking extends EntityProperty<ElementTag> {
             }
             else if (npc.hasTrait(SneakTrait.class)) {
                 npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
-                npc.removeTrait(SneakTrait.class);
             }
             else if (npc.hasTrait(SneakingTrait.class)) { // backsupport
                 npc.getTraitNullable(SneakingTrait.class).stand();

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>net.citizensnpcs</groupId>
             <artifactId>citizens-main</artifactId>
-            <version>2.0.42-SNAPSHOT</version>
+            <version>2.0.43-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/DenizenNPCHelper.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/DenizenNPCHelper.java
@@ -3,15 +3,20 @@ package com.denizenscript.denizen.npc;
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.events.entity.EntityDespawnScriptEvent;
 import com.denizenscript.denizen.npc.actions.ActionHandler;
+import com.denizenscript.denizen.npc.traits.SittingTrait;
+import com.denizenscript.denizen.npc.traits.SleepingTrait;
+import com.denizenscript.denizen.npc.traits.SneakingTrait;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.NPCTag;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.depends.Depends;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import net.citizensnpcs.api.event.NPCDespawnEvent;
-import net.citizensnpcs.api.event.NPCRemoveEvent;
-import net.citizensnpcs.api.event.NPCSpawnEvent;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.event.*;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.trait.SitTrait;
+import net.citizensnpcs.trait.SleepTrait;
+import net.citizensnpcs.trait.SneakTrait;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -19,7 +24,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
-import java.util.*;
+import java.util.Arrays;
 
 public class DenizenNPCHelper implements Listener {
 
@@ -144,5 +149,30 @@ public class DenizenNPCHelper implements Listener {
     public void onRemove(NPCRemoveEvent event) {
         NPC npc = event.getNPC();
         new NPCTag(npc).action("remove", null);
+    }
+
+    // backwards compat: SittingTrait, SleepingTrait, and SneakingTrait are deprecated versions.
+    @EventHandler
+    public void onCitizensEnable(CitizensEnableEvent event) {
+        for (NPC npc : CitizensAPI.getNPCRegistry()) {
+            if (npc.hasTrait(SittingTrait.class)) {
+                if (npc.getOrAddTrait(SittingTrait.class).isSitting()) {
+                    npc.getOrAddTrait(SitTrait.class).setSitting(npc.getStoredLocation());
+                }
+                npc.removeTrait(SittingTrait.class);
+            }
+            if (!SleepingTrait.isSupported() && npc.hasTrait(SleepingTrait.class)) {
+                if (npc.getOrAddTrait(SleepingTrait.class).isSleeping()) {
+                    npc.getOrAddTrait(SleepTrait.class).setSleeping(npc.getStoredLocation());
+                }
+                npc.removeTrait(SleepingTrait.class);
+            }
+            if (npc.hasTrait(SneakingTrait.class)) {
+                if (npc.getOrAddTrait(SneakingTrait.class).isSneaking()) {
+                    npc.getOrAddTrait(SneakTrait.class).setSneaking(true);
+                }
+                npc.removeTrait(SneakingTrait.class);
+            }
+        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SittingTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SittingTrait.java
@@ -28,6 +28,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
 
+@Deprecated(forRemoval = true)
 public class SittingTrait extends Trait implements Listener {
 
     @Persist("sitting")

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SleepingTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SleepingTrait.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.npc.traits;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.utilities.Utilities;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.citizensnpcs.api.persistence.Persist;
@@ -15,6 +16,10 @@ import org.bukkit.event.block.BlockBreakEvent;
 
 @Deprecated(forRemoval = true)
 public class SleepingTrait extends Trait {
+
+    public static boolean isSupported() {
+        return NMSHandler.getVersion().isAtMost(NMSVersion.v1_20);
+    }
 
     @Persist("sleeping")
     private boolean sleeping = false;

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SleepingTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SleepingTrait.java
@@ -9,13 +9,11 @@ import net.citizensnpcs.api.trait.Trait;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.data.type.Bed;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Pose;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.BlockBreakEvent;
 
+@Deprecated(forRemoval = true)
 public class SleepingTrait extends Trait {
 
     @Persist("sleeping")
@@ -47,14 +45,14 @@ public class SleepingTrait extends Trait {
     }
 
     public void internalSleepNow() {
-        if (npc.getEntity() instanceof Villager) {
-            if (!((Villager) npc.getEntity()).sleep(bedLocation.clone())) {
+        if (npc.getEntity() instanceof Villager villager) {
+            if (!villager.sleep(bedLocation.clone())) {
                 return;
             }
         }
-        else if (npc.getEntity() instanceof Player) {
+        else if (npc.getEntity() instanceof Player player) {
             if (bedLocation.getBlock().getBlockData() instanceof Bed) {
-                ((Player) npc.getEntity()).sleep(bedLocation.clone(), true);
+                player.sleep(bedLocation.clone(), true);
             }
             else {
                 NMSHandler.entityHelper.setPose(npc.getEntity(), Pose.SLEEPING);
@@ -115,8 +113,8 @@ public class SleepingTrait extends Trait {
             return;
         }
         sleeping = false;
-        if (npc.getEntity() instanceof Villager) {
-            ((Villager) npc.getEntity()).wakeup();
+        if (npc.getEntity() instanceof Villager villager) {
+            villager.wakeup();
         }
         else {
             if (((Player) npc.getEntity()).isSleeping()) {
@@ -138,7 +136,7 @@ public class SleepingTrait extends Trait {
 
     /**
      * Gets the bed the NPC is sleeping on
-     * Returns null if the NPC isnt sleeping
+     * Returns null if the NPC isn't sleeping
      *
      * @return Location
      */

--- a/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SneakingTrait.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/npc/traits/SneakingTrait.java
@@ -7,6 +7,7 @@ import net.citizensnpcs.api.trait.Trait;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.Listener;
 
+@Deprecated(forRemoval = true)
 public class SneakingTrait extends Trait implements Listener {
 
     @Persist("sneaking")

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
@@ -1771,15 +1771,8 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // <NPCTag.is_sneaking>
         // -->
         tagProcessor.registerMechanism("set_sneaking", false, ElementTag.class, (object, mechanism, input) -> {
-            if (!mechanism.requireBoolean()) {
-                return;
-            }
-            SneakingTrait trait = object.getCitizen().getOrAddTrait(SneakingTrait.class);
-            if (trait.isSneaking() && !input.asBoolean()) {
-                trait.stand();
-            }
-            else if (!trait.isSneaking() && input.asBoolean()) {
-                trait.sneak();
+            if (mechanism.requireBoolean()) {
+                object.getCitizen().getOrAddTrait(SneakTrait.class).setSneaking(input.asBoolean());
             }
         });
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
@@ -491,7 +491,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_sleeping", (attribute, object) -> {
             NPC citizen = object.getCitizen();
-            return new ElementTag(citizen.hasTrait(SleepTrait.class)
+            return new ElementTag((citizen.hasTrait(SleepTrait.class) && citizen.getOrAddTrait(SleepTrait.class).isSleeping())
                                     || (citizen.hasTrait(SleepingTrait.class) && citizen.getOrAddTrait(SleepingTrait.class).isSleeping())); //backsupport
         });
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
@@ -479,8 +479,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_sitting", (attribute, object) -> {
             NPC citizen = object.getCitizen();
-            return new ElementTag((citizen.hasTrait(SitTrait.class) && citizen.getOrAddTrait(SitTrait.class).isSitting())
-                                || (citizen.hasTrait(SittingTrait.class) && citizen.getOrAddTrait(SittingTrait.class).isSitting())); // backsupport
+            return new ElementTag(citizen.hasTrait(SitTrait.class) && citizen.getOrAddTrait(SitTrait.class).isSitting());
         });
 
         // <--[tag]
@@ -491,8 +490,8 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_sleeping", (attribute, object) -> {
             NPC citizen = object.getCitizen();
-            return new ElementTag((NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && citizen.hasTrait(SleepTrait.class) && citizen.getOrAddTrait(SleepTrait.class).isSleeping())
-                                    || (citizen.hasTrait(SleepingTrait.class) && citizen.getOrAddTrait(SleepingTrait.class).isSleeping())); //backsupport
+            return new ElementTag((!SleepingTrait.isSupported() && citizen.hasTrait(SleepTrait.class) && citizen.getOrAddTrait(SleepTrait.class).isSleeping())
+                                    || (SleepingTrait.isSupported() && citizen.hasTrait(SleepingTrait.class) && citizen.getOrAddTrait(SleepingTrait.class).isSleeping()));
         });
 
         // <--[tag]

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
@@ -479,7 +479,8 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_sitting", (attribute, object) -> {
             NPC citizen = object.getCitizen();
-            return new ElementTag(citizen.hasTrait(SittingTrait.class) && citizen.getOrAddTrait(SittingTrait.class).isSitting());
+            return new ElementTag((citizen.hasTrait(SitTrait.class) && citizen.getOrAddTrait(SitTrait.class).isSitting())
+                                || (citizen.hasTrait(SittingTrait.class) && citizen.getOrAddTrait(SittingTrait.class).isSitting())); // backsupport
         });
 
         // <--[tag]
@@ -490,7 +491,8 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_sleeping", (attribute, object) -> {
             NPC citizen = object.getCitizen();
-            return new ElementTag(citizen.hasTrait(SleepingTrait.class) && citizen.getOrAddTrait(SleepingTrait.class).isSleeping());
+            return new ElementTag(citizen.hasTrait(SleepTrait.class)
+                                    || (citizen.hasTrait(SleepingTrait.class) && citizen.getOrAddTrait(SleepingTrait.class).isSleeping())); //backsupport
         });
 
         // <--[tag]
@@ -1821,15 +1823,16 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // <NPCTag.is_sneaking>
         // -->
         if (mechanism.matches("set_sneaking") && mechanism.requireBoolean()) {
-            if (!getCitizen().hasTrait(SneakingTrait.class)) {
-                getCitizen().addTrait(SneakingTrait.class);
+            if (getCitizen().hasTrait(SneakingTrait.class)) { // backsupport
+                getCitizen().getOrAddTrait(SneakingTrait.class).stand();
+                getCitizen().removeTrait(SneakingTrait.class);
             }
-            SneakingTrait trait = getCitizen().getOrAddTrait(SneakingTrait.class);
+            SneakTrait trait = getCitizen().getOrAddTrait(SneakTrait.class);
             if (trait.isSneaking() && !mechanism.getValue().asBoolean()) {
-                trait.stand();
+                trait.setSneaking(false);
             }
             else if (!trait.isSneaking() && mechanism.getValue().asBoolean()) {
-                trait.sneak();
+                trait.setSneaking(true);
             }
         }
 

--- a/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/objects/NPCTag.java
@@ -491,7 +491,7 @@ public class NPCTag implements ObjectTag, Adjustable, InventoryHolder, EntityFor
         // -->
         tagProcessor.registerTag(ElementTag.class, "is_sleeping", (attribute, object) -> {
             NPC citizen = object.getCitizen();
-            return new ElementTag((citizen.hasTrait(SleepTrait.class) && citizen.getOrAddTrait(SleepTrait.class).isSleeping())
+            return new ElementTag((NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && citizen.hasTrait(SleepTrait.class) && citizen.getOrAddTrait(SleepTrait.class).isSleeping())
                                     || (citizen.hasTrait(SleepingTrait.class) && citizen.getOrAddTrait(SleepingTrait.class).isSleeping())); //backsupport
         });
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
@@ -4,14 +4,13 @@ import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.npc.traits.SneakingTrait;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.PlayerTag;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
-import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.trait.SneakTrait;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
@@ -25,6 +24,7 @@ public class SneakCommand extends AbstractCommand {
         setSyntax("sneak [<entity>|...] ({start}/stop) (fake/stopfake) (for:<player>|...)");
         setRequiredArguments(1, 4);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
@@ -38,7 +38,7 @@ public class SneakCommand extends AbstractCommand {
     //
     // @Description
     // Causes an entity to start or stop sneaking.
-    // If the entity is NPC, adds the SneakingTrait to apply the sneak setting persistent.
+    // If the entity is NPC, adds the SneakTrait to apply the sneak setting persistent.
     //
     // Can optionally use the 'fake' argument to apply a fake sneak using packets, either globally or for specific players.
     // Use 'stopfake' to disable faking of sneak.
@@ -60,40 +60,54 @@ public class SneakCommand extends AbstractCommand {
     //
     // -->
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (arg.matches("fake")
-                    && !scriptEntry.hasObject("fake")
-                    && !scriptEntry.hasObject("stopfake")) {
-                scriptEntry.addObject("fake", new ElementTag(true));
+    public enum SneakMode { START, STOP }
+
+    public enum SneakFake { FAKE, STOPFAKE }
+
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("entities") @ArgLinear @ArgDefaultNull List<EntityTag> entities,
+                                   @ArgName("mode") @ArgLinear @ArgDefaultNull SneakMode mode,
+                                   @ArgName("fake") @ArgLinear @ArgDefaultNull SneakFake fake,
+                                   @ArgName("for") @ArgPrefixed @ArgDefaultNull List<PlayerTag> players) {
+        if (entities == null) {
+            throw new InvalidArgumentsRuntimeException("Missing entities argument.");
+        }
+        if (mode == null) {
+            mode = SneakMode.START;
+        }
+        boolean shouldSneak = mode.equals(SneakMode.START);
+        boolean shouldFake = fake != null && fake.equals(SneakFake.FAKE);
+        boolean shouldStopFake = fake != null && fake.equals(SneakFake.STOPFAKE);
+        for (EntityTag entity : entities) {
+            if (shouldFake || shouldStopFake) {
+                if (players == null) {
+                    updateFakeSneak(entity.getUUID(), null, shouldSneak, shouldFake);
+                    for (Player player : NMSHandler.entityHelper.getPlayersThatSee(entity.getBukkitEntity())) {
+                        NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player, entity.getBukkitEntity());
+                    }
+                }
+                else {
+                    for (PlayerTag player : players) {
+                        updateFakeSneak(entity.getUUID(), player.getUUID(), shouldSneak, shouldFake);
+                        NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player.getPlayerEntity(), entity.getBukkitEntity());
+                    }
+                }
             }
-            else if (arg.matches("stopfake")
-                    && !scriptEntry.hasObject("fake")
-                    && !scriptEntry.hasObject("stopfake")) {
-                scriptEntry.addObject("stopfake", new ElementTag(true));
+            else if (entity.isCitizensNPC()) {
+                if (entity.getDenizenNPC().getCitizen().hasTrait(SneakingTrait.class)) {
+                    entity.getDenizenNPC().getCitizen().getOrAddTrait(SneakingTrait.class).stand();
+                    entity.getDenizenNPC().getCitizen().removeTrait(SneakingTrait.class);
+                }
+                SneakTrait trait = entity.getDenizenNPC().getCitizen().getOrAddTrait(SneakTrait.class);
+                trait.setSneaking(shouldSneak);
             }
-            else if ((arg.matches("start") || arg.matches("stop"))
-                    && !scriptEntry.hasObject("mode")) {
-                scriptEntry.addObject("mode", arg.asElement());
-            }
-            else if (arg.matchesPrefix("for")
-                    && arg.matchesArgumentList(PlayerTag.class)
-                    && !scriptEntry.hasObject("for_players")) {
-                scriptEntry.addObject("for_players", arg.asType(ListTag.class).filter(PlayerTag.class, scriptEntry));
-            }
-            else if (arg.matchesArgumentList(EntityTag.class)
-                    && !scriptEntry.hasObject("entities")) {
-                scriptEntry.addObject("entities", arg.asType(ListTag.class).filter(EntityTag.class, scriptEntry));
+            else if (entity.isSpawned()) {
+                NMSHandler.entityHelper.setSneaking(entity.getBukkitEntity(), shouldSneak);
             }
             else {
-                arg.reportUnhandled();
+                Debug.echoError("Cannot make unspawned entity sneak.");
             }
         }
-        if (!scriptEntry.hasObject("entities")) {
-            throw new InvalidArgumentsException("Missing entities argument.");
-        }
-        scriptEntry.defaultObject("mode", new ElementTag("start"));
     }
 
     public static HashMap<UUID, HashMap<UUID, Boolean>> forceSetSneak = new HashMap<>();
@@ -129,51 +143,5 @@ public class SneakCommand extends AbstractCommand {
             return b;
         }
         return subMap.get(null);
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
-        ElementTag fake = scriptEntry.getElement("fake");
-        ElementTag stopfake = scriptEntry.getElement("stopfake");
-        ElementTag mode = scriptEntry.getElement("mode");
-        List<PlayerTag> forPlayers = (List<PlayerTag>) scriptEntry.getObject("for_players");
-        List<EntityTag> entities = (List<EntityTag>) scriptEntry.getObject("entities");
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), mode, db("entities", entities), db("for_players", forPlayers), fake, stopfake);
-        }
-        boolean shouldSneak = mode.asString().equalsIgnoreCase("start");
-        boolean shouldFake = fake != null && fake.asBoolean();
-        boolean shouldStopFake = stopfake != null && stopfake.asBoolean();
-        for (EntityTag entity : entities) {
-            if (shouldFake || shouldStopFake) {
-                if (forPlayers == null) {
-                    updateFakeSneak(entity.getUUID(), null, shouldSneak, shouldFake);
-                    for (Player player : NMSHandler.entityHelper.getPlayersThatSee(entity.getBukkitEntity())) {
-                        NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player, entity.getBukkitEntity());
-                    }
-                }
-                else {
-                    for (PlayerTag player : forPlayers) {
-                        updateFakeSneak(entity.getUUID(), player.getUUID(), shouldSneak, shouldFake);
-                        NMSHandler.packetHelper.sendEntityMetadataFlagsUpdate(player.getPlayerEntity(), entity.getBukkitEntity());
-                    }
-                }
-            }
-            else if (entity.isCitizensNPC()) {
-                SneakingTrait trait = entity.getDenizenNPC().getCitizen().getOrAddTrait(SneakingTrait.class);
-                if (shouldSneak) {
-                    trait.sneak();
-                }
-                else {
-                    trait.stand();
-                }
-            }
-            else if (entity.isSpawned()) {
-                NMSHandler.entityHelper.setSneaking(entity.getBukkitEntity(), shouldSneak);
-            }
-            else {
-                Debug.echoError("Cannot make unspawned entity sneak.");
-            }
-        }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
@@ -10,6 +10,7 @@ import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.SneakTrait;
 import org.bukkit.entity.Player;
 
@@ -65,17 +66,14 @@ public class SneakCommand extends AbstractCommand {
     public enum SneakFake { FAKE, STOPFAKE }
 
     public static void autoExecute(ScriptEntry scriptEntry,
-                                   @ArgName("entities") @ArgLinear @ArgDefaultNull List<EntityTag> entities,
+                                   @ArgName("entities") @ArgLinear @ArgDefaultNull @ArgSubType(EntityTag.class) List<EntityTag> entities,
                                    @ArgName("mode") @ArgLinear @ArgDefaultNull SneakMode mode,
                                    @ArgName("fake") @ArgLinear @ArgDefaultNull SneakFake fake,
-                                   @ArgName("for") @ArgPrefixed @ArgDefaultNull List<PlayerTag> players) {
+                                   @ArgName("for") @ArgPrefixed @ArgDefaultNull @ArgSubType(PlayerTag.class) List<PlayerTag> players) {
         if (entities == null) {
             throw new InvalidArgumentsRuntimeException("Missing entities argument.");
         }
-        if (mode == null) {
-            mode = SneakMode.START;
-        }
-        boolean shouldSneak = mode.equals(SneakMode.START);
+        boolean shouldSneak = mode == null || mode.equals(SneakMode.START);
         boolean shouldFake = fake != null && fake.equals(SneakFake.FAKE);
         boolean shouldStopFake = fake != null && fake.equals(SneakFake.STOPFAKE);
         for (EntityTag entity : entities) {
@@ -94,11 +92,12 @@ public class SneakCommand extends AbstractCommand {
                 }
             }
             else if (entity.isCitizensNPC()) {
-                if (entity.getDenizenNPC().getCitizen().hasTrait(SneakingTrait.class)) {
-                    entity.getDenizenNPC().getCitizen().getOrAddTrait(SneakingTrait.class).stand();
-                    entity.getDenizenNPC().getCitizen().removeTrait(SneakingTrait.class);
+                NPC npc = entity.getDenizenNPC().getCitizen();
+                if (npc.hasTrait(SneakingTrait.class)) {
+                    npc.getOrAddTrait(SneakingTrait.class).stand();
+                    npc.removeTrait(SneakingTrait.class);
                 }
-                SneakTrait trait = entity.getDenizenNPC().getCitizen().getOrAddTrait(SneakTrait.class);
+                SneakTrait trait = npc.getOrAddTrait(SneakTrait.class);
                 trait.setSneaking(shouldSneak);
             }
             else if (entity.isSpawned()) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
@@ -97,8 +97,7 @@ public class SneakCommand extends AbstractCommand {
                     npc.getOrAddTrait(SneakingTrait.class).stand();
                     npc.removeTrait(SneakingTrait.class);
                 }
-                SneakTrait trait = npc.getOrAddTrait(SneakTrait.class);
-                trait.setSneaking(shouldSneak);
+                npc.getOrAddTrait(SneakTrait.class).setSneaking(shouldSneak);
             }
             else if (entity.isSpawned()) {
                 NMSHandler.entityHelper.setSneaking(entity.getBukkitEntity(), shouldSneak);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/SneakCommand.java
@@ -1,7 +1,6 @@
 package com.denizenscript.denizen.scripts.commands.entity;
 
 import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.npc.traits.SneakingTrait;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.utilities.packets.NetworkInterceptHelper;
@@ -10,7 +9,6 @@ import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
-import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.SneakTrait;
 import org.bukkit.entity.Player;
 
@@ -92,12 +90,7 @@ public class SneakCommand extends AbstractCommand {
                 }
             }
             else if (entity.isCitizensNPC()) {
-                NPC npc = entity.getDenizenNPC().getCitizen();
-                if (npc.hasTrait(SneakingTrait.class)) {
-                    npc.getOrAddTrait(SneakingTrait.class).stand();
-                    npc.removeTrait(SneakingTrait.class);
-                }
-                npc.getOrAddTrait(SneakTrait.class).setSneaking(shouldSneak);
+                entity.getDenizenNPC().getCitizen().getOrAddTrait(SneakTrait.class).setSneaking(shouldSneak);
             }
             else if (entity.isSpawned()) {
                 NMSHandler.entityHelper.setSneaking(entity.getBukkitEntity(), shouldSneak);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
@@ -11,7 +11,6 @@ import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.citizensnpcs.trait.SitTrait;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Sittable;
 

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
@@ -1,15 +1,19 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.npc.traits.SittingTrait;
-import com.denizenscript.denizen.objects.LocationTag;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import org.bukkit.entity.*;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.trait.SitTrait;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Sittable;
 
 public class SitCommand extends AbstractCommand {
 
@@ -18,6 +22,7 @@ public class SitCommand extends AbstractCommand {
         setSyntax("sit (<location>)");
         setRequiredArguments(0, 1);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
@@ -42,44 +47,26 @@ public class SitCommand extends AbstractCommand {
     //
     // -->
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (arg.matchesArgumentType(LocationTag.class)
-                    && !scriptEntry.hasObject("location")) {
-                scriptEntry.addObject("location", arg.asType(LocationTag.class));
-            }
-            else {
-                arg.reportUnhandled();
-            }
-        }
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("location") @ArgLinear @ArgDefaultNull LocationTag location) {
         if (!Utilities.entryHasNPC(scriptEntry)) {
-            throw new InvalidArgumentsException("This command requires a linked NPC!");
+            throw new InvalidArgumentsRuntimeException("This command requires a linked NPC!");
         }
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
-        LocationTag location = scriptEntry.getObjectTag("location");
         NPCTag npc = Utilities.getEntryNPC(scriptEntry);
         if (!(npc.getEntity() instanceof Player || npc.getEntity() instanceof Sittable)) {
-            Debug.echoError("Entities of type " + npc.getEntityType().getName() + " cannot sit.");
+            Debug.echoError("Entities of type " + npc.getEntityType() + " cannot sit.");
             return;
         }
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), npc, location);
-        }
-        Entity entity = npc.getEntity();
-        if (entity instanceof Sittable) {
-            ((Sittable) entity).setSitting(true);
+        if (npc.getEntity() instanceof Sittable sittable) {
+            sittable.setSitting(true);
         }
         else {
-            SittingTrait trait = npc.getCitizen().getOrAddTrait(SittingTrait.class);
+            SitTrait trait = npc.getCitizen().getOrAddTrait(SitTrait.class);
             if (location != null) {
-                trait.sit(location);
+                trait.setSitting(location);
             }
             else {
-                trait.sit();
+                trait.setSitting(npc.getLocation());
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
@@ -52,14 +52,10 @@ public class SitCommand extends AbstractCommand {
             throw new InvalidArgumentsRuntimeException("This command requires a linked NPC!");
         }
         NPCTag npc = Utilities.getEntryNPC(scriptEntry);
-        if (!(npc.getEntity() instanceof Player || npc.getEntity() instanceof Sittable)) {
-            Debug.echoError("Entities of type " + npc.getEntityType() + " cannot sit.");
-            return;
-        }
         if (npc.getEntity() instanceof Sittable sittable) {
             sittable.setSitting(true);
         }
-        else {
+        else if (npc.getEntity() instanceof Player) {
             SitTrait trait = npc.getCitizen().getOrAddTrait(SitTrait.class);
             if (location != null) {
                 trait.setSitting(location);
@@ -67,6 +63,9 @@ public class SitCommand extends AbstractCommand {
             else {
                 trait.setSitting(npc.getLocation());
             }
+        }
+        else {
+            Debug.echoError("Entities of type " + npc.getEntityType() + " cannot sit.");
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SitCommand.java
@@ -56,13 +56,7 @@ public class SitCommand extends AbstractCommand {
             sittable.setSitting(true);
         }
         else if (npc.getEntity() instanceof Player) {
-            SitTrait trait = npc.getCitizen().getOrAddTrait(SitTrait.class);
-            if (location != null) {
-                trait.setSitting(location);
-            }
-            else {
-                trait.setSitting(npc.getLocation());
-            }
+            npc.getCitizen().getOrAddTrait(SitTrait.class).setSitting(location != null ? location : npc.getLocation());
         }
         else {
             Debug.echoError("Entities of type " + npc.getEntityType() + " cannot sit.");

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.Utilities;
@@ -10,6 +11,8 @@ import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.trait.SitTrait;
 import net.citizensnpcs.trait.SleepTrait;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
@@ -56,7 +59,15 @@ public class SleepCommand extends AbstractCommand {
             Debug.echoError("Only Player or villager type NPCs can sit!");
             return;
         }
-        SleepTrait trait = npc.getCitizen().getOrAddTrait(SleepTrait.class);
+        NPC citizen = npc.getCitizen();
+        if (citizen.hasTrait(SittingTrait.class)) {
+            citizen.getOrAddTrait(SittingTrait.class).stand();
+            citizen.removeTrait(SittingTrait.class);
+        }
+        if (citizen.hasTrait(SitTrait.class)) {
+            citizen.getOrAddTrait(SitTrait.class).setSitting(null);
+        }
+        SleepTrait trait = citizen.getOrAddTrait(SleepTrait.class);
         if (location != null) {
             trait.setSleeping(location);
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
@@ -1,14 +1,16 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
-import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgDefaultNull;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgLinear;
+import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.trait.SleepTrait;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Villager;
 
@@ -19,6 +21,7 @@ public class SleepCommand extends AbstractCommand {
         setSyntax("sleep (<location>)");
         setRequiredArguments(0, 1);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
@@ -43,42 +46,22 @@ public class SleepCommand extends AbstractCommand {
     //
     // -->
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (arg.matchesArgumentType(LocationTag.class)
-                    && !scriptEntry.hasObject("location")) {
-                scriptEntry.addObject("location", arg.asType(LocationTag.class));
-            }
-            else {
-                arg.reportUnhandled();
-            }
-        }
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("location") @ArgLinear @ArgDefaultNull LocationTag location) {
         if (!Utilities.entryHasNPC(scriptEntry)) {
-            throw new InvalidArgumentsException("This command requires a linked NPC!");
+            throw new InvalidArgumentsRuntimeException("This command requires a linked NPC!");
         }
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
-        LocationTag location = scriptEntry.getObjectTag("location");
         NPCTag npc = Utilities.getEntryNPC(scriptEntry);
         if (npc.getEntityType() != EntityType.PLAYER && !(npc.getEntity() instanceof Villager)) {
             Debug.echoError("Only Player or villager type NPCs can sit!");
             return;
         }
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), npc, location);
-        }
-        SleepingTrait trait = npc.getCitizen().getOrAddTrait(SleepingTrait.class);
+        SleepTrait trait = npc.getCitizen().getOrAddTrait(SleepTrait.class);
         if (location != null) {
-            trait.toSleep(location);
+            trait.setSleeping(location);
         }
         else {
-            trait.toSleep();
-        }
-        if (!trait.isSleeping()) {
-            npc.getCitizen().removeTrait(SleepingTrait.class);
+            trait.setSleeping(npc.getLocation());
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
@@ -1,8 +1,5 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
-import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.NPCTag;
@@ -63,14 +60,10 @@ public class SleepCommand extends AbstractCommand {
             return;
         }
         NPC citizen = npc.getCitizen();
-        if (citizen.hasTrait(SittingTrait.class)) {
-            citizen.getOrAddTrait(SittingTrait.class).stand();
-            citizen.removeTrait(SittingTrait.class);
-        }
         if (citizen.hasTrait(SitTrait.class)) {
             citizen.getOrAddTrait(SitTrait.class).setSitting(null);
         }
-        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) { // backsupport
+        if (SleepingTrait.isSupported()) {
             SleepingTrait trait = citizen.getOrAddTrait(SleepingTrait.class);
             if (location != null) {
                 trait.toSleep(location);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/SleepCommand.java
@@ -1,6 +1,9 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.npc.traits.SittingTrait;
+import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.Utilities;
@@ -67,12 +70,16 @@ public class SleepCommand extends AbstractCommand {
         if (citizen.hasTrait(SitTrait.class)) {
             citizen.getOrAddTrait(SitTrait.class).setSitting(null);
         }
-        SleepTrait trait = citizen.getOrAddTrait(SleepTrait.class);
-        if (location != null) {
-            trait.setSleeping(location);
+        if (NMSHandler.getVersion().isAtMost(NMSVersion.v1_20)) { // backsupport
+            SleepingTrait trait = citizen.getOrAddTrait(SleepingTrait.class);
+            if (location != null) {
+                trait.toSleep(location);
+            }
+            else {
+                trait.toSleep();
+            }
+            return;
         }
-        else {
-            trait.setSleeping(npc.getLocation());
-        }
+        citizen.getOrAddTrait(SleepTrait.class).setSleeping(location != null ? location : npc.getLocation());
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
@@ -59,23 +59,22 @@ public class StandCommand extends AbstractCommand {
         }
         if (npc.getEntity() instanceof Sittable sittable) {
             sittable.setSitting(false);
+            return;
         }
-        else {
-            NPC citizen = npc.getCitizen();
-            if (citizen.hasTrait(SittingTrait.class)) {
-                citizen.getOrAddTrait(SittingTrait.class).stand();
-                citizen.removeTrait(SittingTrait.class);
-            }
-            if (citizen.hasTrait(SitTrait.class)) {
-                citizen.getOrAddTrait(SitTrait.class).setSitting(null);
-            }
-            if (citizen.hasTrait(SleepingTrait.class)) {
-                citizen.getOrAddTrait(SleepingTrait.class).wakeUp();
-                citizen.removeTrait(SleepingTrait.class);
-            }
-            if (citizen.hasTrait(SleepTrait.class)) {
-                citizen.getOrAddTrait(SleepTrait.class).setSleeping(null);
-            }
+        NPC citizen = npc.getCitizen();
+        if (citizen.hasTrait(SittingTrait.class)) {
+            citizen.getOrAddTrait(SittingTrait.class).stand();
+            citizen.removeTrait(SittingTrait.class);
+        }
+        if (citizen.hasTrait(SitTrait.class)) {
+            citizen.getOrAddTrait(SitTrait.class).setSitting(null);
+        }
+        if (citizen.hasTrait(SleepingTrait.class)) {
+            citizen.getOrAddTrait(SleepingTrait.class).wakeUp();
+            citizen.removeTrait(SleepingTrait.class);
+        }
+        if (citizen.hasTrait(SleepTrait.class)) {
+            citizen.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
     }
 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
@@ -1,8 +1,5 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
-import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.Utilities;
@@ -64,20 +61,13 @@ public class StandCommand extends AbstractCommand {
             return;
         }
         NPC citizen = npc.getCitizen();
-        if (citizen.hasTrait(SittingTrait.class)) {
-            citizen.getOrAddTrait(SittingTrait.class).stand();
-            citizen.removeTrait(SittingTrait.class);
-        }
         if (citizen.hasTrait(SitTrait.class)) {
             citizen.getOrAddTrait(SitTrait.class).setSitting(null);
         }
-        if (citizen.hasTrait(SleepingTrait.class)) {
+        if (SleepingTrait.isSupported() && citizen.hasTrait(SleepingTrait.class)) {
             citizen.getOrAddTrait(SleepingTrait.class).wakeUp();
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                citizen.removeTrait(SleepingTrait.class);
-            }
         }
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && citizen.hasTrait(SleepTrait.class)) {
+        if (!SleepingTrait.isSupported() && citizen.hasTrait(SleepTrait.class)) {
             citizen.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.SitTrait;
 import net.citizensnpcs.trait.SleepTrait;
 import org.bukkit.entity.Player;
@@ -60,21 +61,20 @@ public class StandCommand extends AbstractCommand {
             sittable.setSitting(false);
         }
         else {
-            if (npc.getCitizen().hasTrait(SittingTrait.class)) {
-                SittingTrait trait = npc.getCitizen().getOrAddTrait(SittingTrait.class);
-                trait.stand();
-                npc.getCitizen().removeTrait(SittingTrait.class);
+            NPC citizen = npc.getCitizen();
+            if (citizen.hasTrait(SittingTrait.class)) {
+                citizen.getOrAddTrait(SittingTrait.class).stand();
+                citizen.removeTrait(SittingTrait.class);
             }
-            if (npc.getCitizen().hasTrait(SitTrait.class)) {
-                npc.getCitizen().removeTrait(SitTrait.class);
+            if (citizen.hasTrait(SitTrait.class)) {
+                citizen.getOrAddTrait(SitTrait.class).setSitting(null);
             }
-            if (npc.getCitizen().hasTrait(SleepingTrait.class)) {
-                SleepingTrait trait = npc.getCitizen().getOrAddTrait(SleepingTrait.class);
-                trait.wakeUp();
-                npc.getCitizen().removeTrait(SleepingTrait.class);
+            if (citizen.hasTrait(SleepingTrait.class)) {
+                citizen.getOrAddTrait(SleepingTrait.class).wakeUp();
+                citizen.removeTrait(SleepingTrait.class);
             }
-            if (npc.getCitizen().hasTrait(SleepTrait.class)) {
-                npc.getCitizen().removeTrait(SleepTrait.class);
+            if (citizen.hasTrait(SleepTrait.class)) {
+                citizen.getOrAddTrait(SleepTrait.class).setSleeping(null);
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
@@ -1,15 +1,18 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.objects.NPCTag;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizen.npc.traits.SittingTrait;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
-import org.bukkit.entity.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.citizensnpcs.trait.SitTrait;
+import net.citizensnpcs.trait.SleepTrait;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Sittable;
+import org.bukkit.entity.Villager;
 
 public class StandCommand extends AbstractCommand {
 
@@ -18,6 +21,7 @@ public class StandCommand extends AbstractCommand {
         setSyntax("stand");
         setRequiredArguments(0, 0);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
@@ -43,30 +47,17 @@ public class StandCommand extends AbstractCommand {
     //
     // -->
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        //stand should have no additional arguments
-        for (Argument arg : scriptEntry) {
-            arg.reportUnhandled();
-        }
+    public static void autoExecute(ScriptEntry scriptEntry) {
         if (!Utilities.entryHasNPC(scriptEntry)) {
-            throw new InvalidArgumentsException("This command requires a linked NPC!");
+            throw new InvalidArgumentsRuntimeException("This command requires a linked NPC!");
         }
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
         NPCTag npc = Utilities.getEntryNPC(scriptEntry);
         if (!(npc.getEntity() instanceof Player || npc.getEntity() instanceof Sittable || npc.getEntity() instanceof Villager)) {
-            Debug.echoError("Entities of type " + npc.getEntityType().name() + " cannot sit or sleep.");
+            Debug.echoError("Entities of type " + npc.getEntityType() + " cannot sit or sleep.");
             return;
         }
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), db("npc", Utilities.getEntryNPC(scriptEntry)));
-        }
-        Entity entity = npc.getEntity();
-        if (entity instanceof Sittable) {
-            ((Sittable) entity).setSitting(false);
+        if (npc.getEntity() instanceof Sittable sittable) {
+            sittable.setSitting(false);
         }
         else {
             if (npc.getCitizen().hasTrait(SittingTrait.class)) {
@@ -74,10 +65,16 @@ public class StandCommand extends AbstractCommand {
                 trait.stand();
                 npc.getCitizen().removeTrait(SittingTrait.class);
             }
+            if (npc.getCitizen().hasTrait(SitTrait.class)) {
+                npc.getCitizen().removeTrait(SitTrait.class);
+            }
             if (npc.getCitizen().hasTrait(SleepingTrait.class)) {
                 SleepingTrait trait = npc.getCitizen().getOrAddTrait(SleepingTrait.class);
                 trait.wakeUp();
                 npc.getCitizen().removeTrait(SleepingTrait.class);
+            }
+            if (npc.getCitizen().hasTrait(SleepTrait.class)) {
+                npc.getCitizen().removeTrait(SleepTrait.class);
             }
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/StandCommand.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.objects.NPCTag;
@@ -71,9 +73,11 @@ public class StandCommand extends AbstractCommand {
         }
         if (citizen.hasTrait(SleepingTrait.class)) {
             citizen.getOrAddTrait(SleepingTrait.class).wakeUp();
-            citizen.removeTrait(SleepingTrait.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                citizen.removeTrait(SleepingTrait.class);
+            }
         }
-        if (citizen.hasTrait(SleepTrait.class)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && citizen.hasTrait(SleepTrait.class)) {
             citizen.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
@@ -1,5 +1,7 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.npc.traits.SneakingTrait;
@@ -88,7 +90,7 @@ public class TraitCommand extends AbstractCommand {
         if (trait == null) {
             throw new InvalidArgumentsRuntimeException("Trait not found: " + traitName);
         }
-        if (trait == SittingTrait.class || trait == SleepingTrait.class || trait == SneakingTrait.class) {
+        if (trait == SittingTrait.class || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && trait == SleepingTrait.class) || trait == SneakingTrait.class) {
             BukkitImplDeprecations.citizensTraits.warn();
             if (trait == SittingTrait.class) {
                 trait = SitTrait.class;

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
@@ -1,7 +1,5 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.npc.traits.SittingTrait;
 import com.denizenscript.denizen.npc.traits.SleepingTrait;
 import com.denizenscript.denizen.npc.traits.SneakingTrait;
@@ -90,16 +88,16 @@ public class TraitCommand extends AbstractCommand {
         if (trait == null) {
             throw new InvalidArgumentsRuntimeException("Trait not found: " + traitName);
         }
-        if (trait == SittingTrait.class || (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && trait == SleepingTrait.class) || trait == SneakingTrait.class) {
+        if (trait == SittingTrait.class || (!SleepingTrait.isSupported() && trait == SleepingTrait.class) || trait == SneakingTrait.class) {
             BukkitImplDeprecations.citizensTraits.warn();
             if (trait == SittingTrait.class) {
                 trait = SitTrait.class;
             }
-            else if (trait == SleepingTrait.class) {
-                trait = SleepTrait.class;
+            else if (trait == SneakingTrait.class) {
+                trait = SneakTrait.class;
             }
             else {
-                trait = SneakTrait.class;
+                trait = SleepTrait.class;
             }
         }
         if (npcs == null) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
@@ -1,18 +1,23 @@
 package com.denizenscript.denizen.scripts.commands.npc;
 
+import com.denizenscript.denizen.npc.traits.SittingTrait;
+import com.denizenscript.denizen.npc.traits.SleepingTrait;
+import com.denizenscript.denizen.npc.traits.SneakingTrait;
 import com.denizenscript.denizen.objects.NPCTag;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.Utilities;
-import com.denizenscript.denizencore.utilities.debugging.Debug;
-import com.denizenscript.denizencore.exceptions.InvalidArgumentsException;
-import com.denizenscript.denizencore.objects.Argument;
-import com.denizenscript.denizencore.objects.core.ElementTag;
-import com.denizenscript.denizencore.objects.core.ListTag;
+import com.denizenscript.denizencore.exceptions.InvalidArgumentsRuntimeException;
 import com.denizenscript.denizencore.scripts.ScriptEntry;
 import com.denizenscript.denizencore.scripts.commands.AbstractCommand;
+import com.denizenscript.denizencore.scripts.commands.generator.*;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.api.trait.Trait;
 import net.citizensnpcs.api.trait.TraitInfo;
+import net.citizensnpcs.trait.SitTrait;
+import net.citizensnpcs.trait.SleepTrait;
+import net.citizensnpcs.trait.SneakTrait;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +29,7 @@ public class TraitCommand extends AbstractCommand {
         setSyntax("trait (state:true/false/{toggle}) [<trait>] (to:<npc>|...)");
         setRequiredArguments(1, 3);
         isProcedural = false;
+        autoCompile();
     }
 
     // <--[command]
@@ -62,7 +68,7 @@ public class TraitCommand extends AbstractCommand {
     //
     // -->
 
-    private enum Toggle {TOGGLE, TRUE, FALSE, ON, OFF}
+    public enum Toggle {TOGGLE, TRUE, FALSE, ON, OFF}
 
     @Override
     public void addCustomTabCompletions(TabCompletionsBuilder tab) {
@@ -71,66 +77,54 @@ public class TraitCommand extends AbstractCommand {
         }
     }
 
-    @Override
-    public void parseArgs(ScriptEntry scriptEntry) throws InvalidArgumentsException {
-        for (Argument arg : scriptEntry) {
-            if (!scriptEntry.hasObject("state")
-                    && arg.matchesPrefix("state", "s")
-                    && arg.matchesEnum(Toggle.class)) {
-                scriptEntry.addObject("state", new ElementTag(arg.getValue().toUpperCase()));
-            }
-            else if (!scriptEntry.hasObject("trait")) {
-                scriptEntry.addObject("trait", new ElementTag(arg.getValue()));
-            }
-            else if (!scriptEntry.hasObject("npcs")
-                    && arg.matchesArgumentList(NPCTag.class)) {
-                scriptEntry.addObject("npcs", arg.asType(ListTag.class).filter(NPCTag.class, scriptEntry));
-            }
-            else {
-                arg.reportUnhandled();
-            }
+    public static void autoExecute(ScriptEntry scriptEntry,
+                                   @ArgName("state") @ArgPrefixed @ArgDefaultNull Toggle toggle,
+                                   @ArgName("trait") @ArgLinear @ArgDefaultNull Trait traitName,
+                                   @ArgName("to") @ArgPrefixed @ArgDefaultNull List<NPCTag> npcs) {
+        if (traitName == null) {
+            throw new InvalidArgumentsRuntimeException("Missing trait argument!");
         }
-        if (!scriptEntry.hasObject("trait")) {
-            throw new InvalidArgumentsException("Missing trait argument!");
-        }
-        if (!scriptEntry.hasObject("npcs")) {
+        if (npcs == null) {
             if (!Utilities.entryHasNPC(scriptEntry)) {
-                throw new InvalidArgumentsException("This command requires a linked NPC!");
+                throw new InvalidArgumentsRuntimeException("This command requires a linked NPC!");
             }
-            scriptEntry.addObject("npcs", Collections.singletonList(Utilities.getEntryNPC(scriptEntry)));
+            npcs = Collections.singletonList(Utilities.getEntryNPC(scriptEntry));
         }
-        scriptEntry.defaultObject("state", new ElementTag("TOGGLE"));
-    }
-
-    @Override
-    public void execute(ScriptEntry scriptEntry) {
-        ElementTag toggle = scriptEntry.getElement("state");
-        ElementTag traitName = scriptEntry.getElement("trait");
-        List<NPCTag> npcs = (List<NPCTag>) scriptEntry.getObject("npcs");
-        if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), traitName, toggle, db("npc", npcs));
+        if (toggle == null) {
+            toggle = Toggle.TOGGLE;
         }
-        Class<? extends Trait> trait = CitizensAPI.getTraitFactory().getTraitClass(traitName.asString());
+        Class<? extends Trait> trait = CitizensAPI.getTraitFactory().getTraitClass(traitName.getName());
         if (trait == null) {
-            Debug.echoError(scriptEntry, "Trait not found: " + traitName.asString());
+            Debug.echoError(scriptEntry, "Trait not found: " + traitName.getName());
             return;
         }
         for (NPCTag npcTag : npcs) {
             NPC npc = npcTag.getCitizen();
-            switch (Toggle.valueOf(toggle.asString())) {
+            switch (toggle) {
                 case TRUE:
                 case ON:
                     if (npc.hasTrait(trait)) {
-                        Debug.echoError(scriptEntry, "NPC already has trait '" + traitName.asString() + "'");
+                        Debug.echoError(scriptEntry, "NPC already has trait '" + traitName.getName() + "'");
+                        break;
                     }
-                    else {
-                        npc.addTrait(trait);
+                    if (trait == SittingTrait.class || trait == SleepingTrait.class || trait == SneakingTrait.class) {
+                        BukkitImplDeprecations.citizensTraits.warn();
+                        if (trait == SittingTrait.class) {
+                            trait = SitTrait.class;
+                        }
+                        else if (trait == SleepingTrait.class) {
+                            trait = SleepTrait.class;
+                        }
+                        else {
+                            trait = SneakTrait.class;
+                        }
                     }
+                    npc.addTrait(trait);
                     break;
                 case FALSE:
                 case OFF:
                     if (!npc.hasTrait(trait)) {
-                        Debug.echoError(scriptEntry, "NPC does not have trait '" + traitName.asString() + "'");
+                        Debug.echoError(scriptEntry, "NPC does not have trait '" + traitName.getName() + "'");
                     }
                     else {
                         npc.removeTrait(trait);
@@ -139,10 +133,21 @@ public class TraitCommand extends AbstractCommand {
                 case TOGGLE:
                     if (npc.hasTrait(trait)) {
                         npc.removeTrait(trait);
+                        break;
                     }
-                    else {
-                        npc.addTrait(trait);
+                    if (trait == SittingTrait.class || trait == SleepingTrait.class || trait == SneakingTrait.class) {
+                        BukkitImplDeprecations.citizensTraits.warn();
+                        if (trait == SittingTrait.class) {
+                            trait = SitTrait.class;
+                        }
+                        else if (trait == SleepingTrait.class) {
+                            trait = SleepTrait.class;
+                        }
+                        else {
+                            trait = SneakTrait.class;
+                        }
                     }
+                    npc.addTrait(trait);
                     break;
             }
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/npc/TraitCommand.java
@@ -79,10 +79,26 @@ public class TraitCommand extends AbstractCommand {
 
     public static void autoExecute(ScriptEntry scriptEntry,
                                    @ArgName("state") @ArgPrefixed @ArgDefaultNull Toggle toggle,
-                                   @ArgName("trait") @ArgLinear @ArgDefaultNull Trait traitName,
-                                   @ArgName("to") @ArgPrefixed @ArgDefaultNull List<NPCTag> npcs) {
+                                   @ArgName("trait") @ArgLinear @ArgDefaultNull String traitName,
+                                   @ArgName("to") @ArgPrefixed @ArgDefaultNull @ArgSubType(NPCTag.class) List<NPCTag> npcs) {
         if (traitName == null) {
             throw new InvalidArgumentsRuntimeException("Missing trait argument!");
+        }
+        Class<? extends Trait> trait = CitizensAPI.getTraitFactory().getTraitClass(traitName);
+        if (trait == null) {
+            throw new InvalidArgumentsRuntimeException("Trait not found: " + traitName);
+        }
+        if (trait == SittingTrait.class || trait == SleepingTrait.class || trait == SneakingTrait.class) {
+            BukkitImplDeprecations.citizensTraits.warn();
+            if (trait == SittingTrait.class) {
+                trait = SitTrait.class;
+            }
+            else if (trait == SleepingTrait.class) {
+                trait = SleepTrait.class;
+            }
+            else {
+                trait = SneakTrait.class;
+            }
         }
         if (npcs == null) {
             if (!Utilities.entryHasNPC(scriptEntry)) {
@@ -90,62 +106,30 @@ public class TraitCommand extends AbstractCommand {
             }
             npcs = Collections.singletonList(Utilities.getEntryNPC(scriptEntry));
         }
-        if (toggle == null) {
-            toggle = Toggle.TOGGLE;
-        }
-        Class<? extends Trait> trait = CitizensAPI.getTraitFactory().getTraitClass(traitName.getName());
-        if (trait == null) {
-            Debug.echoError(scriptEntry, "Trait not found: " + traitName.getName());
-            return;
-        }
         for (NPCTag npcTag : npcs) {
             NPC npc = npcTag.getCitizen();
             switch (toggle) {
                 case TRUE:
                 case ON:
                     if (npc.hasTrait(trait)) {
-                        Debug.echoError(scriptEntry, "NPC already has trait '" + traitName.getName() + "'");
+                        Debug.echoError(scriptEntry, "NPC already has trait '" + trait.getName() + "'");
                         break;
-                    }
-                    if (trait == SittingTrait.class || trait == SleepingTrait.class || trait == SneakingTrait.class) {
-                        BukkitImplDeprecations.citizensTraits.warn();
-                        if (trait == SittingTrait.class) {
-                            trait = SitTrait.class;
-                        }
-                        else if (trait == SleepingTrait.class) {
-                            trait = SleepTrait.class;
-                        }
-                        else {
-                            trait = SneakTrait.class;
-                        }
                     }
                     npc.addTrait(trait);
                     break;
                 case FALSE:
                 case OFF:
                     if (!npc.hasTrait(trait)) {
-                        Debug.echoError(scriptEntry, "NPC does not have trait '" + traitName.getName() + "'");
+                        Debug.echoError(scriptEntry, "NPC does not have trait '" + trait.getName() + "'");
                     }
                     else {
                         npc.removeTrait(trait);
                     }
                     break;
-                case TOGGLE:
+                default:
                     if (npc.hasTrait(trait)) {
                         npc.removeTrait(trait);
                         break;
-                    }
-                    if (trait == SittingTrait.class || trait == SleepingTrait.class || trait == SneakingTrait.class) {
-                        BukkitImplDeprecations.citizensTraits.warn();
-                        if (trait == SittingTrait.class) {
-                            trait = SitTrait.class;
-                        }
-                        else if (trait == SleepingTrait.class) {
-                            trait = SleepTrait.class;
-                        }
-                        else {
-                            trait = SneakTrait.class;
-                        }
                     }
                     npc.addTrait(trait);
                     break;

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -490,7 +490,7 @@ public class BukkitImplDeprecations {
     public static Warning playerSteerEntityEvent = new FutureWarning("playerSteerEntityEvent", "The 'player steers <entity>' event is deprecated in favor of the 'player input' event in MC 1.21+.");
 
     // Added 2026/07/02
-    public static Warning citizensTraits = new FutureWarning("citizensTraits", "The Denizen-native 'SittingTrait', 'SleepingTrait', and 'SneakingTrait' traits have been removed in favor of Citizens' 'SitTrait', 'SleepTrait', and 'SneakTrait' respectively.");
+    public static Warning citizensTraits = new FutureWarning("citizensTraits", "The Denizen-native 'Sitting', 'Sleeping', and 'Sneaking' traits have been removed in favor of Citizens' 'SitTrait', 'SleepTrait', and 'Sneak' traits respectively.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -489,6 +489,9 @@ public class BukkitImplDeprecations {
     // Added 2025/09/22
     public static Warning playerSteerEntityEvent = new FutureWarning("playerSteerEntityEvent", "The 'player steers <entity>' event is deprecated in favor of the 'player input' event in MC 1.21+.");
 
+    // Added 2026/07/02
+    public static Warning citizensTraits = new FutureWarning("citizensTraits", "The Denizen-native 'SittingTrait', 'SleepingTrait', and 'SneakingTrait' traits have been removed in favor of Citizens' 'SitTrait', 'SleepTrait', and 'SneakTrait' respectively.");
+
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 
     // Removed upstream 2025/02/15

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -489,9 +489,8 @@ public class BukkitImplDeprecations {
     // Added 2025/09/22
     public static Warning playerSteerEntityEvent = new FutureWarning("playerSteerEntityEvent", "The 'player steers <entity>' event is deprecated in favor of the 'player input' event in MC 1.21+.");
 
-    // Added 2026/07/15
+    // Added 2026/07/22
     public static Warning citizensTraits = new FutureWarning("citizensTraits", "The Denizen-native 'Sitting', 'Sleeping', and 'Sneaking' traits have been removed in favor of Citizens' 'SitTrait', 'SleepTrait', and 'Sneak' traits respectively.");
-    public static Warning npcSitCommand = new FutureWarning("npcSitCommand", "The Denizen-native '/npc sit' has been deprecated in favor of Citizens' '/npc sitting'.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/BukkitImplDeprecations.java
@@ -489,8 +489,9 @@ public class BukkitImplDeprecations {
     // Added 2025/09/22
     public static Warning playerSteerEntityEvent = new FutureWarning("playerSteerEntityEvent", "The 'player steers <entity>' event is deprecated in favor of the 'player input' event in MC 1.21+.");
 
-    // Added 2026/07/02
+    // Added 2026/07/15
     public static Warning citizensTraits = new FutureWarning("citizensTraits", "The Denizen-native 'Sitting', 'Sleeping', and 'Sneaking' traits have been removed in favor of Citizens' 'SitTrait', 'SleepTrait', and 'Sneak' traits respectively.");
+    public static Warning npcSitCommand = new FutureWarning("npcSitCommand", "The Denizen-native '/npc sit' has been deprecated in favor of Citizens' '/npc sitting'.");
 
     // ==================== PAST deprecations of things that are already gone but still have a warning left behind ====================
 

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -343,14 +343,13 @@ public class NPCCommandHandler {
         }
         if (npc.hasTrait(SneakTrait.class)) {
             npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
-            npc.removeTrait(SneakTrait.class);
         }
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             npc.removeTrait(SleepingTrait.class);
         }
         if (npc.hasTrait(SleepTrait.class)) {
-            npc.removeTrait(SleepTrait.class);
+            npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
         if (npc.hasTrait(SittingTrait.class)) {
             npc.getOrAddTrait(SittingTrait.class).stand();
@@ -432,7 +431,7 @@ public class NPCCommandHandler {
                 Messaging.sendError(sender, npc.getName() + " is already standing!");
                 return;
             }
-            npc.removeTrait(SitTrait.class);
+            trait.setSitting(null);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else if (npc.hasTrait(SneakingTrait.class)) {
@@ -467,7 +466,7 @@ public class NPCCommandHandler {
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else if (npc.hasTrait(SleepTrait.class)) {
-            npc.removeTrait(SleepTrait.class);
+            npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else {
@@ -487,24 +486,18 @@ public class NPCCommandHandler {
         }
         if (npc.hasTrait(SneakTrait.class)) {
             npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
-            npc.removeTrait(SneakTrait.class);
         }
         if (npc.hasTrait(SittingTrait.class)) {
             npc.getOrAddTrait(SittingTrait.class).stand();
             npc.removeTrait(SittingTrait.class);
         }
         if (npc.hasTrait(SitTrait.class)) {
-            npc.removeTrait(SitTrait.class);
+            npc.getOrAddTrait(SitTrait.class).setSitting(null);
         }
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
             npc.removeTrait(SleepingTrait.class);
-            return;
-        }
-        if (npc.hasTrait(SleepTrait.class)) {
-            Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
-            npc.removeTrait(SleepTrait.class);
             return;
         }
         SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
@@ -546,7 +539,7 @@ public class NPCCommandHandler {
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
         else if (npc.hasTrait(SleepTrait.class)) {
-            npc.removeTrait(SleepTrait.class);
+            npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
         else {
@@ -648,14 +641,14 @@ public class NPCCommandHandler {
             npc.removeTrait(SleepingTrait.class);
         }
         if (npc.hasTrait(SleepTrait.class)) {
-            npc.removeTrait(SleepTrait.class);
+            npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
         if (npc.hasTrait(SittingTrait.class)) {
             npc.getOrAddTrait(SittingTrait.class).stand();
             npc.removeTrait(SittingTrait.class);
         }
         if (npc.hasTrait(SitTrait.class)) {
-            npc.removeTrait(SitTrait.class);
+            npc.getOrAddTrait(SitTrait.class).setSitting(null);
         }
         if (npc.hasTrait(SneakingTrait.class)) {
             npc.getOrAddTrait(SneakingTrait.class).stand();

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -466,7 +466,12 @@ public class NPCCommandHandler {
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else if (npc.hasTrait(SleepTrait.class)) {
-            npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
+            SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
+            if (!trait.isSleeping()) {
+                Messaging.sendError(sender, npc.getName() + " is already standing!");
+                return;
+            }
+            trait.setSleeping(null);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else {
@@ -501,6 +506,11 @@ public class NPCCommandHandler {
             return;
         }
         SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
+        if (trait.isSleeping()) {
+            trait.setSleeping(null);
+            Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
+            return;
+        }
         if (args.hasValueFlag("location")) {
             LocationTag location = LocationTag.valueOf(args.getFlag("location"), CoreUtilities.basicContext);
             if (location == null) {
@@ -538,7 +548,7 @@ public class NPCCommandHandler {
             npc.removeTrait(SleepingTrait.class);
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
-        else if (npc.hasTrait(SleepTrait.class)) {
+        else if (npc.hasTrait(SleepTrait.class) && npc.getOrAddTrait(SleepTrait.class).isSleeping()) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -1,14 +1,11 @@
 package com.denizenscript.denizen.utilities.command;
 
 import com.denizenscript.denizen.Denizen;
-import com.denizenscript.denizen.nms.NMSHandler;
-import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.npc.traits.*;
 import com.denizenscript.denizen.npc.traits.MirrorTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.scripts.containers.core.AssignmentScriptContainer;
-import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.command.manager.messaging.Messaging;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.scripts.ScriptRegistry;
@@ -340,26 +337,14 @@ public class NPCCommandHandler {
             min = 1, max = 3, permission = "denizen.npc.sit")
     @Requirements(selected = true, ownership = true)
     public void sitting(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
-        BukkitImplDeprecations.npcSitCommand.warn();
-        if (npc.hasTrait(SneakingTrait.class)) {
-            npc.getOrAddTrait(SneakingTrait.class).stand();
-            npc.removeTrait(SneakingTrait.class);
-        }
         if (npc.hasTrait(SneakTrait.class)) {
             npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
         }
-        if (npc.hasTrait(SleepingTrait.class)) {
+        if (SleepingTrait.isSupported() && npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                npc.removeTrait(SleepingTrait.class);
-            }
         }
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class)) {
+        if (!SleepingTrait.isSupported() && npc.hasTrait(SleepTrait.class)) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
-        }
-        if (npc.hasTrait(SittingTrait.class)) {
-            npc.getOrAddTrait(SittingTrait.class).stand();
-            npc.removeTrait(SittingTrait.class);
         }
         SitTrait trait = npc.getOrAddTrait(SitTrait.class);
         if (args.hasValueFlag("location")) {
@@ -420,35 +405,13 @@ public class NPCCommandHandler {
             min = 1, max = 1, permission = "denizen.npc.stand")
     @Requirements(selected = true, ownership = true)
     public void standing(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
-        if (npc.hasTrait(SittingTrait.class)) {
-            SittingTrait trait = npc.getOrAddTrait(SittingTrait.class);
-            if (!trait.isSitting()) {
-                npc.removeTrait(SittingTrait.class);
-                Messaging.sendError(sender, npc.getName() + " is already standing!");
-                return;
-            }
-            trait.stand();
-            npc.removeTrait(SittingTrait.class);
-            Messaging.send(sender, npc.getName() + " is now standing.");
-        }
-        else if (npc.hasTrait(SitTrait.class)) {
+        if (npc.hasTrait(SitTrait.class)) {
             SitTrait trait = npc.getOrAddTrait(SitTrait.class);
             if (!trait.isSitting()) {
                 Messaging.sendError(sender, npc.getName() + " is already standing!");
                 return;
             }
             trait.setSitting(null);
-            Messaging.send(sender, npc.getName() + " is now standing.");
-        }
-        else if (npc.hasTrait(SneakingTrait.class)) {
-            SneakingTrait trait = npc.getOrAddTrait(SneakingTrait.class);
-            if (!trait.isSneaking()) {
-                npc.removeTrait(SneakingTrait.class);
-                Messaging.sendError(sender, npc.getName() + " is already standing!");
-                return;
-            }
-            trait.stand();
-            npc.removeTrait(SneakingTrait.class);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else if (npc.hasTrait(SneakTrait.class)) {
@@ -460,22 +423,16 @@ public class NPCCommandHandler {
             trait.setSneaking(false);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
-        else if (npc.hasTrait(SleepingTrait.class)) {
+        else if (SleepingTrait.isSupported() && npc.hasTrait(SleepingTrait.class)) {
             SleepingTrait trait = npc.getOrAddTrait(SleepingTrait.class);
             if (!trait.isSleeping()) {
-                if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                    npc.removeTrait(SleepingTrait.class);
-                }
                 Messaging.sendError(sender, npc.getName() + " is already standing!");
                 return;
             }
             trait.wakeUp();
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                npc.removeTrait(SleepingTrait.class);
-            }
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class)) {
+        else if (!SleepingTrait.isSupported() && npc.hasTrait(SleepTrait.class)) {
             SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
             if (!trait.isSleeping()) {
                 Messaging.sendError(sender, npc.getName() + " is already standing!");
@@ -495,30 +452,47 @@ public class NPCCommandHandler {
             min = 1, max = 3, permission = "denizen.npc.sleep")
     @Requirements(selected = true, ownership = true, types = { EntityType.VILLAGER, EntityType.PLAYER })
     public void sleeping(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
-        if (npc.hasTrait(SneakingTrait.class)) {
-            npc.getOrAddTrait(SneakingTrait.class).stand();
-            npc.removeTrait(SneakingTrait.class);
-        }
         if (npc.hasTrait(SneakTrait.class)) {
             npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
-        }
-        if (npc.hasTrait(SittingTrait.class)) {
-            npc.getOrAddTrait(SittingTrait.class).stand();
-            npc.removeTrait(SittingTrait.class);
         }
         if (npc.hasTrait(SitTrait.class)) {
             npc.getOrAddTrait(SitTrait.class).setSitting(null);
         }
-        if (npc.hasTrait(SleepingTrait.class)) {
+        if (SleepingTrait.isSupported() && npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                npc.removeTrait(SleepingTrait.class);
+            return;
+        }
+        if (SleepingTrait.isSupported()) {
+            SleepingTrait trait = npc.getOrAddTrait(SleepingTrait.class);
+            if (args.hasValueFlag("location")) {
+                LocationTag location = LocationTag.valueOf(args.getFlag("location"), CoreUtilities.basicContext);
+                if (location == null) {
+                    Messaging.sendError(sender, "Usage: /npc sleep --location x,y,z,world");
+                    return;
+                }
+                trait.toSleep(location);
             }
+            else if (args.hasValueFlag("anchor")) {
+                if (npc.hasTrait(Anchors.class)) {
+                    Anchors anchors = npc.getOrAddTrait(Anchors.class);
+                    if (anchors.getAnchor(args.getFlag("anchor")) != null) {
+                        trait.toSleep(anchors.getAnchor(args.getFlag("anchor")).getLocation().clone().add(0.5, 0, 0.5));
+                        Messaging.send(sender, npc.getName() + " is now sleeping.");
+                        return;
+                    }
+                }
+                Messaging.sendError(sender, "NPC " + npc.getName() + "<f> does not have the anchor '" + args.getFlag("anchor") + "'!");
+                return;
+            }
+            else {
+                trait.toSleep(npc.getStoredLocation());
+            }
+            Messaging.send(sender, npc.getName() + " is now sleeping.");
             return;
         }
         SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && trait.isSleeping()) {
+        if (trait.isSleeping()) {
             trait.setSleeping(null);
             Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
             return;
@@ -555,14 +529,11 @@ public class NPCCommandHandler {
             min = 1, max = 1, permission = "denizen.npc.sleep")
     @Requirements(selected = true, ownership = true)
     public void wakingup(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
-        if (npc.hasTrait(SleepingTrait.class)) {
+        if (SleepingTrait.isSupported() && npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                npc.removeTrait(SleepingTrait.class);
-            }
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
-        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class) && npc.getOrAddTrait(SleepTrait.class).isSleeping()) {
+        else if (!SleepingTrait.isSupported() && npc.hasTrait(SleepTrait.class) && npc.getOrAddTrait(SleepTrait.class).isSleeping()) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
@@ -660,25 +631,14 @@ public class NPCCommandHandler {
             min = 1, max = 1, permission = "denizen.npc.sneak")
     @Requirements(selected = true, ownership = true)
     public void sneaking(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
-        if (npc.hasTrait(SleepingTrait.class)) {
+        if (SleepingTrait.isSupported() && npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
-                npc.removeTrait(SleepingTrait.class);
-            }
         }
-        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class)) {
+        if (!SleepingTrait.isSupported() && npc.hasTrait(SleepTrait.class)) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
-        }
-        if (npc.hasTrait(SittingTrait.class)) {
-            npc.getOrAddTrait(SittingTrait.class).stand();
-            npc.removeTrait(SittingTrait.class);
         }
         if (npc.hasTrait(SitTrait.class)) {
             npc.getOrAddTrait(SitTrait.class).setSitting(null);
-        }
-        if (npc.hasTrait(SneakingTrait.class)) {
-            npc.getOrAddTrait(SneakingTrait.class).stand();
-            npc.removeTrait(SneakingTrait.class);
         }
         if (npc.getEntity().getType() != EntityType.PLAYER) {
             Messaging.sendError(sender, npc.getName() + " needs to be a Player type NPC to sneak!");

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -8,6 +8,7 @@ import com.denizenscript.denizen.npc.traits.MirrorTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.scripts.containers.core.AssignmentScriptContainer;
+import com.denizenscript.denizen.utilities.BukkitImplDeprecations;
 import com.denizenscript.denizen.utilities.command.manager.messaging.Messaging;
 import com.denizenscript.denizencore.objects.core.DurationTag;
 import com.denizenscript.denizencore.scripts.ScriptRegistry;
@@ -339,6 +340,7 @@ public class NPCCommandHandler {
             min = 1, max = 3, permission = "denizen.npc.sit")
     @Requirements(selected = true, ownership = true)
     public void sitting(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
+        BukkitImplDeprecations.npcSitCommand.warn();
         if (npc.hasTrait(SneakingTrait.class)) {
             npc.getOrAddTrait(SneakingTrait.class).stand();
             npc.removeTrait(SneakingTrait.class);

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -1,6 +1,8 @@
 package com.denizenscript.denizen.utilities.command;
 
 import com.denizenscript.denizen.Denizen;
+import com.denizenscript.denizen.nms.NMSHandler;
+import com.denizenscript.denizen.nms.NMSVersion;
 import com.denizenscript.denizen.npc.traits.*;
 import com.denizenscript.denizen.npc.traits.MirrorTrait;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -346,9 +348,11 @@ public class NPCCommandHandler {
         }
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            npc.removeTrait(SleepingTrait.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                npc.removeTrait(SleepingTrait.class);
+            }
         }
-        if (npc.hasTrait(SleepTrait.class)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class)) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
         if (npc.hasTrait(SittingTrait.class)) {
@@ -457,15 +461,19 @@ public class NPCCommandHandler {
         else if (npc.hasTrait(SleepingTrait.class)) {
             SleepingTrait trait = npc.getOrAddTrait(SleepingTrait.class);
             if (!trait.isSleeping()) {
-                npc.removeTrait(SleepingTrait.class);
+                if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                    npc.removeTrait(SleepingTrait.class);
+                }
                 Messaging.sendError(sender, npc.getName() + " is already standing!");
                 return;
             }
             trait.wakeUp();
-            npc.removeTrait(SleepingTrait.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                npc.removeTrait(SleepingTrait.class);
+            }
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
-        else if (npc.hasTrait(SleepTrait.class)) {
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class)) {
             SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
             if (!trait.isSleeping()) {
                 Messaging.sendError(sender, npc.getName() + " is already standing!");
@@ -502,11 +510,13 @@ public class NPCCommandHandler {
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
-            npc.removeTrait(SleepingTrait.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                npc.removeTrait(SleepingTrait.class);
+            }
             return;
         }
         SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
-        if (trait.isSleeping()) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && trait.isSleeping()) {
             trait.setSleeping(null);
             Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
             return;
@@ -532,7 +542,7 @@ public class NPCCommandHandler {
             return;
         }
         else {
-            trait.setSleeping(null);
+            trait.setSleeping(npc.getStoredLocation());
         }
         Messaging.send(sender, npc.getName() + " is now sleeping.");
     }
@@ -545,10 +555,12 @@ public class NPCCommandHandler {
     public void wakingup(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            npc.removeTrait(SleepingTrait.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                npc.removeTrait(SleepingTrait.class);
+            }
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
-        else if (npc.hasTrait(SleepTrait.class) && npc.getOrAddTrait(SleepTrait.class).isSleeping()) {
+        else if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class) && npc.getOrAddTrait(SleepTrait.class).isSleeping()) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
             Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
@@ -648,9 +660,11 @@ public class NPCCommandHandler {
     public void sneaking(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            npc.removeTrait(SleepingTrait.class);
+            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21)) {
+                npc.removeTrait(SleepingTrait.class);
+            }
         }
-        if (npc.hasTrait(SleepTrait.class)) {
+        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_21) && npc.hasTrait(SleepTrait.class)) {
             npc.getOrAddTrait(SleepTrait.class).setSleeping(null);
         }
         if (npc.hasTrait(SittingTrait.class)) {

--- a/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/utilities/command/NPCCommandHandler.java
@@ -2,6 +2,7 @@ package com.denizenscript.denizen.utilities.command;
 
 import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.npc.traits.*;
+import com.denizenscript.denizen.npc.traits.MirrorTrait;
 import com.denizenscript.denizen.objects.LocationTag;
 import com.denizenscript.denizen.objects.PlayerTag;
 import com.denizenscript.denizen.scripts.containers.core.AssignmentScriptContainer;
@@ -16,7 +17,7 @@ import net.citizensnpcs.api.command.CommandContext;
 import net.citizensnpcs.api.command.Requirements;
 import net.citizensnpcs.api.command.exception.CommandException;
 import net.citizensnpcs.api.npc.NPC;
-import net.citizensnpcs.trait.Anchors;
+import net.citizensnpcs.trait.*;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
@@ -340,25 +341,36 @@ public class NPCCommandHandler {
             npc.getOrAddTrait(SneakingTrait.class).stand();
             npc.removeTrait(SneakingTrait.class);
         }
+        if (npc.hasTrait(SneakTrait.class)) {
+            npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
+            npc.removeTrait(SneakTrait.class);
+        }
         if (npc.hasTrait(SleepingTrait.class)) {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             npc.removeTrait(SleepingTrait.class);
         }
-        SittingTrait trait = npc.getOrAddTrait(SittingTrait.class);
+        if (npc.hasTrait(SleepTrait.class)) {
+            npc.removeTrait(SleepTrait.class);
+        }
+        if (npc.hasTrait(SittingTrait.class)) {
+            npc.getOrAddTrait(SittingTrait.class).stand();
+            npc.removeTrait(SittingTrait.class);
+        }
+        SitTrait trait = npc.getOrAddTrait(SitTrait.class);
         if (args.hasValueFlag("location")) {
             LocationTag location = LocationTag.valueOf(args.getFlag("location"), CoreUtilities.basicContext);
             if (location == null) {
                 Messaging.sendError(sender, "Usage: /npc sit --location x,y,z,world");
                 return;
             }
-            trait.sit(location);
+            trait.setSitting(location);
             return;
         }
         else if (args.hasValueFlag("anchor")) {
             if (npc.hasTrait(Anchors.class)) {
                 Anchors anchors = npc.getOrAddTrait(Anchors.class);
                 if (anchors.getAnchor(args.getFlag("anchor")) != null) {
-                    trait.sit(anchors.getAnchor(args.getFlag("anchor")).getLocation());
+                    trait.setSitting(anchors.getAnchor(args.getFlag("anchor")).getLocation());
                     Messaging.send(sender, npc.getName() + " is now sitting.");
                     return;
                 }
@@ -381,7 +393,7 @@ public class NPCCommandHandler {
         }
         Block block = targetLocation.getBlock();
         BlockData data = block.getBlockData();
-        if (data instanceof Stairs || data instanceof Bed || (data instanceof Slab && ((Slab) data).getType() == Slab.Type.BOTTOM)) {
+        if (data instanceof Stairs || data instanceof Bed || (data instanceof Slab slab && slab.getType() == Slab.Type.BOTTOM)) {
             targetLocation.setY(targetLocation.getBlockY() + 0.3);
         }
         else if (data instanceof Campfire) {
@@ -393,7 +405,7 @@ public class NPCCommandHandler {
         else if (block.getType().isSolid()) {
             targetLocation.setY(targetLocation.getBlockY() + 0.8);
         }
-        trait.sit(targetLocation);
+        trait.setSitting(targetLocation);
         Messaging.send(sender, npc.getName() + " is now sitting.");
     }
 
@@ -414,6 +426,15 @@ public class NPCCommandHandler {
             npc.removeTrait(SittingTrait.class);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
+        else if (npc.hasTrait(SitTrait.class)) {
+            SitTrait trait = npc.getOrAddTrait(SitTrait.class);
+            if (!trait.isSitting()) {
+                Messaging.sendError(sender, npc.getName() + " is already standing!");
+                return;
+            }
+            npc.removeTrait(SitTrait.class);
+            Messaging.send(sender, npc.getName() + " is now standing.");
+        }
         else if (npc.hasTrait(SneakingTrait.class)) {
             SneakingTrait trait = npc.getOrAddTrait(SneakingTrait.class);
             if (!trait.isSneaking()) {
@@ -425,6 +446,15 @@ public class NPCCommandHandler {
             npc.removeTrait(SneakingTrait.class);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
+        else if (npc.hasTrait(SneakTrait.class)) {
+            SneakTrait trait = npc.getOrAddTrait(SneakTrait.class);
+            if (!trait.isSneaking()) {
+                Messaging.sendError(sender, npc.getName() + " is already standing!");
+                return;
+            }
+            trait.setSneaking(false);
+            Messaging.send(sender, npc.getName() + " is now standing.");
+        }
         else if (npc.hasTrait(SleepingTrait.class)) {
             SleepingTrait trait = npc.getOrAddTrait(SleepingTrait.class);
             if (!trait.isSleeping()) {
@@ -434,6 +464,10 @@ public class NPCCommandHandler {
             }
             trait.wakeUp();
             npc.removeTrait(SleepingTrait.class);
+            Messaging.send(sender, npc.getName() + " is now standing.");
+        }
+        else if (npc.hasTrait(SleepTrait.class)) {
+            npc.removeTrait(SleepTrait.class);
             Messaging.send(sender, npc.getName() + " is now standing.");
         }
         else {
@@ -451,30 +485,42 @@ public class NPCCommandHandler {
             npc.getOrAddTrait(SneakingTrait.class).stand();
             npc.removeTrait(SneakingTrait.class);
         }
+        if (npc.hasTrait(SneakTrait.class)) {
+            npc.getOrAddTrait(SneakTrait.class).setSneaking(false);
+            npc.removeTrait(SneakTrait.class);
+        }
         if (npc.hasTrait(SittingTrait.class)) {
             npc.getOrAddTrait(SittingTrait.class).stand();
             npc.removeTrait(SittingTrait.class);
         }
-        SleepingTrait trait = npc.getOrAddTrait(SleepingTrait.class);
-        if (trait.isSleeping()) {
+        if (npc.hasTrait(SitTrait.class)) {
+            npc.removeTrait(SitTrait.class);
+        }
+        if (npc.hasTrait(SleepingTrait.class)) {
+            npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
-            trait.wakeUp();
             npc.removeTrait(SleepingTrait.class);
             return;
         }
+        if (npc.hasTrait(SleepTrait.class)) {
+            Messaging.send(sender, npc.getName() + " was already sleeping, and is now standing!");
+            npc.removeTrait(SleepTrait.class);
+            return;
+        }
+        SleepTrait trait = npc.getOrAddTrait(SleepTrait.class);
         if (args.hasValueFlag("location")) {
             LocationTag location = LocationTag.valueOf(args.getFlag("location"), CoreUtilities.basicContext);
             if (location == null) {
                 Messaging.sendError(sender, "Usage: /npc sleep --location x,y,z,world");
                 return;
             }
-            trait.toSleep(location);
+            trait.setSleeping(location);
         }
         else if (args.hasValueFlag("anchor")) {
             if (npc.hasTrait(Anchors.class)) {
                 Anchors anchors = npc.getOrAddTrait(Anchors.class);
                 if (anchors.getAnchor(args.getFlag("anchor")) != null) {
-                    trait.toSleep(anchors.getAnchor(args.getFlag("anchor")).getLocation().clone().add(0.5, 0, 0.5));
+                    trait.setSleeping(anchors.getAnchor(args.getFlag("anchor")).getLocation().clone().add(0.5, 0, 0.5));
                     Messaging.send(sender, npc.getName() + " is now sleeping.");
                     return;
                 }
@@ -483,10 +529,7 @@ public class NPCCommandHandler {
             return;
         }
         else {
-            trait.toSleep();
-        }
-        if (!trait.isSleeping()) {
-            npc.removeTrait(SleepingTrait.class);
+            trait.setSleeping(null);
         }
         Messaging.send(sender, npc.getName() + " is now sleeping.");
     }
@@ -497,15 +540,18 @@ public class NPCCommandHandler {
             min = 1, max = 1, permission = "denizen.npc.sleep")
     @Requirements(selected = true, ownership = true)
     public void wakingup(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
-        SleepingTrait trait = npc.getOrAddTrait(SleepingTrait.class);
-        if (!trait.isSleeping()) {
+        if (npc.hasTrait(SleepingTrait.class)) {
+            npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             npc.removeTrait(SleepingTrait.class);
-            Messaging.sendError(sender, npc.getName() + " is already awake!");
-            return;
+            Messaging.send(sender, npc.getName() + " is no longer sleeping.");
         }
-        trait.wakeUp();
-        npc.removeTrait(SleepingTrait.class);
-        Messaging.send(sender, npc.getName() + " is no longer sleeping.");
+        else if (npc.hasTrait(SleepTrait.class)) {
+            npc.removeTrait(SleepTrait.class);
+            Messaging.send(sender, npc.getName() + " is no longer sleeping.");
+        }
+        else {
+            Messaging.sendError(sender, npc.getName() + " is already awake!");
+        }
     }
 
     @Command(
@@ -601,21 +647,31 @@ public class NPCCommandHandler {
             npc.getOrAddTrait(SleepingTrait.class).wakeUp();
             npc.removeTrait(SleepingTrait.class);
         }
-        if (npc.hasTrait(SleepingTrait.class)) {
-            npc.getOrAddTrait(SleepingTrait.class).wakeUp();
-            npc.removeTrait(SleepingTrait.class);
+        if (npc.hasTrait(SleepTrait.class)) {
+            npc.removeTrait(SleepTrait.class);
+        }
+        if (npc.hasTrait(SittingTrait.class)) {
+            npc.getOrAddTrait(SittingTrait.class).stand();
+            npc.removeTrait(SittingTrait.class);
+        }
+        if (npc.hasTrait(SitTrait.class)) {
+            npc.removeTrait(SitTrait.class);
+        }
+        if (npc.hasTrait(SneakingTrait.class)) {
+            npc.getOrAddTrait(SneakingTrait.class).stand();
+            npc.removeTrait(SneakingTrait.class);
         }
         if (npc.getEntity().getType() != EntityType.PLAYER) {
             Messaging.sendError(sender, npc.getName() + " needs to be a Player type NPC to sneak!");
             return;
         }
-        SneakingTrait trait = npc.getOrAddTrait(SneakingTrait.class);
+        SneakTrait trait = npc.getOrAddTrait(SneakTrait.class);
         if (trait.isSneaking()) {
-            trait.stand();
+            trait.setSneaking(false);
             Messaging.send(sender, npc.getName() + " was already sneaking, and is now standing.");
         }
         else {
-            trait.sneak();
+            trait.setSneaking(true);
             Messaging.send(sender, npc.getName() + " is now sneaking.");
         }
     }


### PR DESCRIPTION
Deprecated Denizen's `SittingTrait`, `SleepingTrait`, and `SneakingTrait` traits for Citizens' `SitTrait`, `SleepTrait`, and `Sneak` traits. 

NPC will be updated to the new version when any of these traits are adjusted through mechanisms or the `/npc` command. 

Fixes a bug reported at https://discord.com/channels/315163488085475337/1508455250594631794.

~~Requires https://github.com/CitizensDev/Citizens2/pull/3321 to be merged first.~~ This has been merged, but the build using this method (b4215) or higher is needed for MC 1.21+.