### PR TITLE
add `copy_to` argument to `createworld` command

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
@@ -26,17 +26,17 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
 
     public CreateWorldCommand() {
         setName("createworld");
-        setSyntax("createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false)");
-        setRequiredArguments(1, 8);
-        setPrefixesHandled("generator", "worldtype", "environment", "copy_from", "seed", "settings", "generate_structures");
+        setSyntax("createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false) (copy_to:<path>)");
+        setRequiredArguments(1, 9);
+        setPrefixesHandled("generator", "worldtype", "environment", "copy_from", "seed", "settings", "generate_structures", "copy_to");
         isProcedural = false;
     }
 
     // <--[command]
     // @Name CreateWorld
-    // @Syntax createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false)
+    // @Syntax createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false) (copy_to:<path>)
     // @Required 1
-    // @Maximum 8
+    // @Maximum 9
     // @Short Creates a new world, or loads an existing world.
     // @Synonyms LoadWorld
     // @Group world
@@ -59,6 +59,8 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
     //
     // Optionally specify an existing world to copy files from.
     // The 'copy_from' argument is ~waitable. Refer to <@link language ~waitable>.
+    //
+    // Optionally specify a 'copy_to' path, which overrides the folder name the files are copied into (useful for datapack dimensions).
     //
     // It's often ideal to put this command inside <@link event server prestart>.
     //
@@ -121,17 +123,21 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
         ElementTag worldType = scriptEntry.argForPrefixAsElement("worldtype", "NORMAL");
         ElementTag environment = scriptEntry.argForPrefixAsElement("environment", "NORMAL");
         ElementTag copy_from = scriptEntry.argForPrefixAsElement("copy_from", null);
+        ElementTag copy_to = scriptEntry.argForPrefixAsElement("copy_to", null);
         ElementTag settings = scriptEntry.argForPrefixAsElement("settings", null);
         ElementTag seed = scriptEntry.argForPrefixAsElement("seed", null);
         ElementTag generateStructures = scriptEntry.argForPrefixAsElement("generate_structures", null);
         if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), worldName, generator, environment, copy_from, settings, worldType, seed, generateStructures);
+            Debug.report(scriptEntry, getName(), worldName, generator, environment, copy_from, copy_to, settings, worldType, seed, generateStructures);
         }
         if (Bukkit.getWorld(worldName.asString()) != null) {
             Debug.echoDebug(scriptEntry, "CreateWorld doing nothing, world by that name already loaded.");
             scriptEntry.setFinished(true);
             return;
         }
+        String targetFolder = copy_to != null ? copy_to.asString() : worldName.asString();
+        String sourceFolder = copy_from != null ? copy_from.asString().replace("w@", "") : null;
+
         if (!Settings.cache_createWorldSymbols) {
             if (forbiddenSymbols.containsAnyMatch(worldName.asString())) {
                 Debug.echoError("Cannot use world names with non-alphanumeric symbols due to security settings in Denizen/config.yml.");
@@ -140,7 +146,7 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
             }
         }
         else if (!Settings.cache_createWorldWeirdPaths) {
-            String cleaned = worldName.asLowerString().replace('\\', '/');
+            String cleaned = targetFolder.toLowerCase().replace('\\', '/');
             while (cleaned.contains("//")) {
                 cleaned = cleaned.replace("//", "/");
             }
@@ -157,8 +163,28 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
                 scriptEntry.setFinished(true);
                 return;
             }
+
+            if (sourceFolder != null) {
+                String cleanedSource = sourceFolder.toLowerCase().replace('\\', '/');
+                while (cleanedSource.contains("//")) {
+                    cleanedSource = cleanedSource.replace("//", "/");
+                }
+                if (cleanedSource.startsWith("/")) {
+                    cleanedSource = cleanedSource.substring(1);
+                }
+                if (cleanedSource.startsWith("plugins/")) {
+                    Debug.echoError("CreateWorld cannot copy from a folder inside plugins due to security settings in Denizen/config.yml.");
+                    scriptEntry.setFinished(true);
+                    return;
+                }
+                if (cleanedSource.startsWith("..")) {
+                    Debug.echoError("CreateWorld cannot copy from a world with a raised path (contains '..') due to security settings in Denizen/config.yml.");
+                    scriptEntry.setFinished(true);
+                    return;
+                }
+            }
         }
-        final File newFolder = new File(Bukkit.getWorldContainer(), worldName.asString());
+        final File newFolder = new File(Bukkit.getWorldContainer(), targetFolder);
         if (!Utilities.canWriteToFile(newFolder)) {
             Debug.echoError("Cannot copy to that new folder path due to security settings in Denizen/config.yml.");
             scriptEntry.setFinished(true);
@@ -175,14 +201,10 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
             scriptEntry.setFinished(true);
             return;
         }
-        if (copy_from != null && !Settings.cache_createWorldSymbols && forbiddenSymbols.containsAnyMatch(copy_from.asString())) {
-            Debug.echoError("Cannot use copy_from world names with non-alphanumeric symbols due to security settings in Denizen/config.yml.");
-            scriptEntry.setFinished(true);
-            return;
-        }
+
         Supplier<Boolean> copyRunnable = () -> {
             try {
-                File folder = new File(Bukkit.getWorldContainer(), copy_from.asString().replace("w@", ""));
+                File folder = new File(Bukkit.getWorldContainer(), sourceFolder);
                 if (!Utilities.canReadFile(folder)) {
                     Debug.echoError(scriptEntry, "Cannot copy from that folder path due to security settings in Denizen/config.yml.");
                     return false;
@@ -197,11 +219,11 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
                 }
                 CoreUtilities.copyDirectory(folder, newFolder, excludedExtensionsForCopyFrom);
                 Debug.echoDebug(scriptEntry, "Copied " + folder.getName() + " to " + newFolder.getName());
-                File file = new File(Bukkit.getWorldContainer(), worldName.asString() + "/uid.dat");
+                File file = new File(Bukkit.getWorldContainer(), targetFolder + "/uid.dat");
                 if (file.exists()) {
                     file.delete();
                 }
-                File file2 = new File(Bukkit.getWorldContainer(), worldName.asString() + "/session.lock");
+                File file2 = new File(Bukkit.getWorldContainer(), targetFolder + "/session.lock");
                 if (file2.exists()) {
                     file2.delete();
                 }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/world/CreateWorldCommand.java
@@ -26,17 +26,17 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
 
     public CreateWorldCommand() {
         setName("createworld");
-        setSyntax("createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false) (copy_to:<path>)");
-        setRequiredArguments(1, 9);
-        setPrefixesHandled("generator", "worldtype", "environment", "copy_from", "seed", "settings", "generate_structures", "copy_to");
+        setSyntax("createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false)");
+        setRequiredArguments(1, 8);
+        setPrefixesHandled("generator", "worldtype", "environment", "copy_from", "seed", "settings", "generate_structures");
         isProcedural = false;
     }
 
     // <--[command]
     // @Name CreateWorld
-    // @Syntax createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false) (copy_to:<path>)
+    // @Syntax createworld [<name>] (generator:<id>) (worldtype:<type>) (environment:<environment>) (copy_from:<world>) (seed:<seed>) (settings:<json>) (generate_structures:true/false)
     // @Required 1
-    // @Maximum 9
+    // @Maximum 8
     // @Short Creates a new world, or loads an existing world.
     // @Synonyms LoadWorld
     // @Group world
@@ -59,8 +59,6 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
     //
     // Optionally specify an existing world to copy files from.
     // The 'copy_from' argument is ~waitable. Refer to <@link language ~waitable>.
-    //
-    // Optionally specify a 'copy_to' path, which overrides the folder name the files are copied into (useful for datapack dimensions).
     //
     // It's often ideal to put this command inside <@link event server prestart>.
     //
@@ -128,25 +126,25 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
         ElementTag seed = scriptEntry.argForPrefixAsElement("seed", null);
         ElementTag generateStructures = scriptEntry.argForPrefixAsElement("generate_structures", null);
         if (scriptEntry.dbCallShouldDebug()) {
-            Debug.report(scriptEntry, getName(), worldName, generator, environment, copy_from, copy_to, settings, worldType, seed, generateStructures);
+            Debug.report(scriptEntry, getName(), worldName, generator, environment, copy_from, settings, worldType, seed, generateStructures);
         }
         if (Bukkit.getWorld(worldName.asString()) != null) {
             Debug.echoDebug(scriptEntry, "CreateWorld doing nothing, world by that name already loaded.");
             scriptEntry.setFinished(true);
             return;
         }
-        String targetFolder = copy_to != null ? copy_to.asString() : worldName.asString();
+        String worldNameStr = worldName.asString();
         String sourceFolder = copy_from != null ? copy_from.asString().replace("w@", "") : null;
 
         if (!Settings.cache_createWorldSymbols) {
-            if (forbiddenSymbols.containsAnyMatch(worldName.asString())) {
+            if (forbiddenSymbols.containsAnyMatch(worldNameStr)) {
                 Debug.echoError("Cannot use world names with non-alphanumeric symbols due to security settings in Denizen/config.yml.");
                 scriptEntry.setFinished(true);
                 return;
             }
         }
         else if (!Settings.cache_createWorldWeirdPaths) {
-            String cleaned = targetFolder.toLowerCase().replace('\\', '/');
+            String cleaned = worldNameStr.toLowerCase().replace('\\', '/');
             while (cleaned.contains("//")) {
                 cleaned = cleaned.replace("//", "/");
             }
@@ -184,7 +182,15 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
                 }
             }
         }
-        final File newFolder = new File(Bukkit.getWorldContainer(), targetFolder);
+        final File newFolder;
+        if (worldNameStr.contains(":")) {
+            String[] split = worldNameStr.split(":", 2);
+            newFolder = new File(new File(new File(Bukkit.getWorlds().get(0).getWorldFolder(), "dimensions"), split[0]), split[1]);
+        }
+        else {
+            newFolder = new File(Bukkit.getWorldContainer(), worldNameStr);
+        }
+
         if (!Utilities.canWriteToFile(newFolder)) {
             Debug.echoError("Cannot copy to that new folder path due to security settings in Denizen/config.yml.");
             scriptEntry.setFinished(true);
@@ -219,11 +225,11 @@ public class CreateWorldCommand extends AbstractCommand implements Holdable {
                 }
                 CoreUtilities.copyDirectory(folder, newFolder, excludedExtensionsForCopyFrom);
                 Debug.echoDebug(scriptEntry, "Copied " + folder.getName() + " to " + newFolder.getName());
-                File file = new File(Bukkit.getWorldContainer(), targetFolder + "/uid.dat");
+                File file = new File(newFolder, "uid.dat");
                 if (file.exists()) {
                     file.delete();
                 }
-                File file2 = new File(Bukkit.getWorldContainer(), targetFolder + "/session.lock");
+                File file2 = new File(newFolder, "session.lock");
                 if (file2.exists()) {
                     file2.delete();
                 }


### PR DESCRIPTION
### Summary

this pull request adds a new `copy_to` argument to the `createworld` command, allowing scripters to specify custom destination folder paths. this fixes pathing conflicts when initializing or copying worlds into modern datapack dimension subdirectories (eg, `world/dimensions/minecraft/...`).

### Problem

when using `createworld` with `copy_from`, we previously locked the file destination path directly to the server root using `Bukkit.getWorldContainer()` plus the world name; with modern vanilla and Paper datapack dimensions, Bukkit initializes the dimension inside nested subfolders while Denizen was copying files to the root directory, completely ignoring the template files. the strict `forbiddenSymbols` security check was rejecting any paths containing forward slashes (`/`), stopping scripters from passing normalized subdirectories entirely also which is going to be very necessary with world path formatting.

### Testing

- [x] Tested on the latest supported patch-versions
- [x] Verified `copy_to` correctly redirects file operations and lock cleanup (eg, `uid.dat`, `session.lock`) to the custom folder path while preserving standard Bukkit world registration
used various testing examples:
- `~createworld test_dimension copy_from:my_template copy_to:world/dimensions/minecraft/test_dimension`
- `~createworld mwtown_city copy_from:world/dimensions/minecraft/the_end environment:THE_END copy_to:world/dimensions/something/mwtown_city`; 

here's a startup log referencing this test with tags parsed for verification: 
https://files.behr.dev/file-share/createworld-copy-to-branch-latest.log

A working build of my latest successful build which has no errors can be built with this branch or found at:
https://files.behr.dev/file-share/denizen-createworld-copy-to.jar