### PR TITLE
fix look command `offthread_repeat` math and mounted rotation

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/LookCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/LookCommand.java
@@ -127,87 +127,87 @@ public class LookCommand extends AbstractCommand {
         final float yawRaw = yaw == null ? 0 : yaw.asFloat();
         final float pitchRaw = pitch == null ? 0 : pitch.asFloat();
         for (EntityTag entity : entities) {
-            if (entity.isSpawned()) {
-                Entity bukkitEntity = entity.getBukkitEntity();
-                Entity vehicle = bukkitEntity.getVehicle();
+            if (!entity.isSpawned()) {
+                continue;
+            }
+            Entity bukkitEntity = entity.getBukkitEntity();
+            Entity vehicle = bukkitEntity.getVehicle();
+
+            if (vehicle != null) {
+                bukkitEntity.leaveVehicle();
+            }
+
+            if (loc != null) {
+                NMSHandler.entityHelper.faceLocation(bukkitEntity, loc);
+            }
+            else if (entity.isPlayer()) {
+                Location playerTeleDest = entity.getLocation().clone();
+                float relYaw = (yawRaw - playerTeleDest.getYaw()) % 360;
+                if (relYaw > 180) {
+                    relYaw -= 360;
+                }
+                float relPitch = pitchRaw - playerTeleDest.getPitch();
+                playerTeleDest.setYaw(yawRaw);
+                playerTeleDest.setPitch(pitchRaw);
+                Player player = entity.getPlayer();
 
                 if (vehicle != null) {
-                    bukkitEntity.leaveVehicle();
+                    PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
                 }
+                else {
+                    final int times = offthreadRepeats != null ? offthreadRepeats.asInt() : 0;
+                    final float stepYaw = times > 0 ? relYaw / (times + 1) : relYaw;
+                    final float stepPitch = times > 0 ? relPitch / (times + 1) : relPitch;
 
-                if (loc != null) {
-                    NMSHandler.entityHelper.faceLocation(bukkitEntity, loc);
-                }
-                else if (entity.isPlayer()) {
-                    Location playerTeleDest = entity.getLocation().clone();
-                    float relYaw = (yawRaw - playerTeleDest.getYaw()) % 360;
-                    if (relYaw > 180) {
-                        relYaw -= 360;
-                    }
-                    final float actualRelYaw = relYaw;
-                    float relPitch = pitchRaw - playerTeleDest.getPitch();
-                    playerTeleDest.setYaw(yawRaw);
-                    playerTeleDest.setPitch(pitchRaw);
-                    Player player = entity.getPlayer();
-
-                    if (vehicle != null) {
-                        PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
+                    if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+                        NetworkInterceptHelper.enable();
+                        NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
                     }
                     else {
-                        final int times = offthreadRepeats != null ? offthreadRepeats.asInt() : 0;
-                        final float stepYaw = times > 0 ? actualRelYaw / (times + 1) : actualRelYaw;
-                        final float stepPitch = times > 0 ? relPitch / (times + 1) : relPitch;
+                        PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
+                    }
 
-                        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-                            NetworkInterceptHelper.enable();
-                            NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
-                        }
-                        else {
-                            PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
-                        }
+                    if (offthreadRepeats != null) {
+                        NetworkInterceptHelper.enable();
+                        int ms = 50 / (times + 1);
+                        DenizenCore.runAsync(() -> {
+                            try {
+                                for (int i = 0; i < times; i++) {
+                                    Thread.sleep(ms);
+                                    NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
+                                }
+                            }
+                            catch (Throwable ex) {
+                                Debug.echoError(ex);
+                            }
+                        });
+                    }
+                }
+            }
+            else {
+                NMSHandler.entityHelper.rotate(bukkitEntity, yawRaw, pitchRaw);
+            }
 
-                        if (offthreadRepeats != null) {
-                            NetworkInterceptHelper.enable();
-                            int ms = 50 / (times + 1);
-                            DenizenCore.runAsync(() -> {
-                                try {
-                                    for (int i = 0; i < times; i++) {
-                                        Thread.sleep(ms);
-                                        NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
-                                    }
-                                }
-                                catch (Throwable ex) {
-                                    Debug.echoError(ex);
-                                }
-                            });
-                        }
+            if (vehicle != null) {
+                Location vLoc = vehicle.getLocation().clone();
+                if (loc != null) {
+                    Vector dir = loc.toVector().subtract(vLoc.toVector());
+                    if (dir.lengthSquared() > 0) {
+                        vLoc.setDirection(dir);
                     }
                 }
                 else {
-                    NMSHandler.entityHelper.rotate(bukkitEntity, yawRaw, pitchRaw);
+                    vLoc.setYaw(yawRaw);
+                    vLoc.setPitch(pitchRaw);
                 }
+                
+                vehicle.teleport(vLoc, PlayerTeleportEvent.TeleportCause.PLUGIN);
 
-                if (vehicle != null) {
-                    Location vLoc = vehicle.getLocation().clone();
-                    if (loc != null) {
-                        Vector dir = loc.toVector().subtract(vLoc.toVector());
-                        if (dir.lengthSquared() > 0) {
-                            vLoc.setDirection(dir);
-                        }
+                Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
+                    if (vehicle.isValid() && bukkitEntity.isValid()) {
+                        vehicle.addPassenger(bukkitEntity);
                     }
-                    else {
-                        vLoc.setYaw(yawRaw);
-                        vLoc.setPitch(pitchRaw);
-                    }
-                    
-                    vehicle.teleport(vLoc, PlayerTeleportEvent.TeleportCause.PLUGIN);
-
-                    Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
-                        if (vehicle.isValid() && bukkitEntity.isValid()) {
-                            vehicle.addPassenger(bukkitEntity);
-                        }
-                    });
-                }
+                });
             }
         }
         if (duration != null && duration.getTicks() > 1) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/LookCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/LookCommand.java
@@ -23,11 +23,14 @@ import com.denizenscript.denizencore.scripts.commands.generator.ArgName;
 import com.denizenscript.denizencore.scripts.commands.generator.ArgPrefixed;
 import com.denizenscript.denizencore.utilities.Deprecations;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.util.Vector;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -125,8 +128,8 @@ public class LookCommand extends AbstractCommand {
         final float pitchRaw = pitch == null ? 0 : pitch.asFloat();
         for (EntityTag entity : entities) {
             if (entity.isSpawned()) {
-                org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
-                org.bukkit.entity.Entity vehicle = bukkitEntity.getVehicle();
+                Entity bukkitEntity = entity.getBukkitEntity();
+                Entity vehicle = bukkitEntity.getVehicle();
 
                 if (vehicle != null) {
                     bukkitEntity.leaveVehicle();
@@ -134,68 +137,72 @@ public class LookCommand extends AbstractCommand {
 
                 if (loc != null) {
                     NMSHandler.entityHelper.faceLocation(bukkitEntity, loc);
-                } else {
-                    if (entity.isPlayer()) {
-                        Location playerTeleDest = entity.getLocation().clone();
-                        float relYaw = (yawRaw - playerTeleDest.getYaw()) % 360;
-                        if (relYaw > 180) {
-                            relYaw -= 360;
-                        }
-                        final float actualRelYaw = relYaw;
-                        float relPitch = pitchRaw - playerTeleDest.getPitch();
-                        playerTeleDest.setYaw(yawRaw);
-                        playerTeleDest.setPitch(pitchRaw);
-                        Player player = entity.getPlayer();
-
-                        if (vehicle != null) {
-                            PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
-                        } else {
-                            final int times = offthreadRepeats != null ? offthreadRepeats.asInt() : 0;
-                            final float stepYaw = times > 0 ? actualRelYaw / (times + 1) : actualRelYaw;
-                            final float stepPitch = times > 0 ? relPitch / (times + 1) : relPitch;
-
-                            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-                                NetworkInterceptHelper.enable();
-                                NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
-                            } else {
-                                PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
-                            }
-
-                            if (offthreadRepeats != null) {
-                                NetworkInterceptHelper.enable();
-                                int ms = 50 / (times + 1);
-                                DenizenCore.runAsync(() -> {
-                                    try {
-                                        for (int i = 0; i < times; i++) {
-                                            Thread.sleep(ms);
-                                            NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
-                                        }
-                                    } catch (Throwable ex) {
-                                        Debug.echoError(ex);
-                                    }
-                                });
-                            }
-                        }
-                    } else {
-                        NMSHandler.entityHelper.rotate(bukkitEntity, yawRaw, pitchRaw);
+                }
+                else if (entity.isPlayer()) {
+                    Location playerTeleDest = entity.getLocation().clone();
+                    float relYaw = (yawRaw - playerTeleDest.getYaw()) % 360;
+                    if (relYaw > 180) {
+                        relYaw -= 360;
                     }
+                    final float actualRelYaw = relYaw;
+                    float relPitch = pitchRaw - playerTeleDest.getPitch();
+                    playerTeleDest.setYaw(yawRaw);
+                    playerTeleDest.setPitch(pitchRaw);
+                    Player player = entity.getPlayer();
+
+                    if (vehicle != null) {
+                        PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
+                    }
+                    else {
+                        final int times = offthreadRepeats != null ? offthreadRepeats.asInt() : 0;
+                        final float stepYaw = times > 0 ? actualRelYaw / (times + 1) : actualRelYaw;
+                        final float stepPitch = times > 0 ? relPitch / (times + 1) : relPitch;
+
+                        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+                            NetworkInterceptHelper.enable();
+                            NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
+                        }
+                        else {
+                            PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
+                        }
+
+                        if (offthreadRepeats != null) {
+                            NetworkInterceptHelper.enable();
+                            int ms = 50 / (times + 1);
+                            DenizenCore.runAsync(() -> {
+                                try {
+                                    for (int i = 0; i < times; i++) {
+                                        Thread.sleep(ms);
+                                        NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
+                                    }
+                                }
+                                catch (Throwable ex) {
+                                    Debug.echoError(ex);
+                                }
+                            });
+                        }
+                    }
+                }
+                else {
+                    NMSHandler.entityHelper.rotate(bukkitEntity, yawRaw, pitchRaw);
                 }
 
                 if (vehicle != null) {
                     Location vLoc = vehicle.getLocation().clone();
                     if (loc != null) {
-                        org.bukkit.util.Vector dir = loc.toVector().subtract(vLoc.toVector());
+                        Vector dir = loc.toVector().subtract(vLoc.toVector());
                         if (dir.lengthSquared() > 0) {
                             vLoc.setDirection(dir);
                         }
-                    } else {
+                    }
+                    else {
                         vLoc.setYaw(yawRaw);
                         vLoc.setPitch(pitchRaw);
                     }
                     
                     vehicle.teleport(vLoc, PlayerTeleportEvent.TeleportCause.PLUGIN);
 
-                    org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                    Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
                         if (vehicle.isValid() && bukkitEntity.isValid()) {
                             vehicle.addPassenger(bukkitEntity);
                         }
@@ -216,15 +223,16 @@ public class LookCommand extends AbstractCommand {
                             return;
                         }
                         if (entity.isSpawned()) {
-                            org.bukkit.entity.Entity target = entity.getBukkitEntity();
-                            org.bukkit.entity.Entity vehicle = target.getVehicle();
+                            Entity target = entity.getBukkitEntity();
+                            Entity vehicle = target.getVehicle();
 
                             if (loc != null) {
                                 NMSHandler.entityHelper.faceLocation(target, loc);
                                 if (vehicle != null) {
                                     NMSHandler.entityHelper.faceLocation(vehicle, loc);
                                 }
-                            } else {
+                            }
+                            else {
                                 NMSHandler.entityHelper.rotate(target, yawRaw, pitchRaw);
                                 if (vehicle != null) {
                                     NMSHandler.entityHelper.rotate(vehicle, yawRaw, pitchRaw);

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/LookCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/LookCommand.java
@@ -125,10 +125,16 @@ public class LookCommand extends AbstractCommand {
         final float pitchRaw = pitch == null ? 0 : pitch.asFloat();
         for (EntityTag entity : entities) {
             if (entity.isSpawned()) {
-                if (loc != null) {
-                    NMSHandler.entityHelper.faceLocation(entity.getBukkitEntity(), loc);
+                org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
+                org.bukkit.entity.Entity vehicle = bukkitEntity.getVehicle();
+
+                if (vehicle != null) {
+                    bukkitEntity.leaveVehicle();
                 }
-                else {
+
+                if (loc != null) {
+                    NMSHandler.entityHelper.faceLocation(bukkitEntity, loc);
+                } else {
                     if (entity.isPlayer()) {
                         Location playerTeleDest = entity.getLocation().clone();
                         float relYaw = (yawRaw - playerTeleDest.getYaw()) % 360;
@@ -140,33 +146,60 @@ public class LookCommand extends AbstractCommand {
                         playerTeleDest.setYaw(yawRaw);
                         playerTeleDest.setPitch(pitchRaw);
                         Player player = entity.getPlayer();
-                        if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
-                            NetworkInterceptHelper.enable();
-                            NMSHandler.packetHelper.sendRelativeLookPacket(player, actualRelYaw, relPitch);
-                        }
-                        else {
+
+                        if (vehicle != null) {
                             PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
-                        }
-                        if (offthreadRepeats != null) {
-                            NetworkInterceptHelper.enable();
-                            int times = offthreadRepeats.asInt();
-                            int ms = 50 / (times + 1);
-                            DenizenCore.runAsync(() -> {
-                                try {
-                                    for (int i = 0; i < times; i++) {
-                                        Thread.sleep(ms);
-                                        NMSHandler.packetHelper.sendRelativeLookPacket(player, actualRelYaw, relPitch);
+                        } else {
+                            final int times = offthreadRepeats != null ? offthreadRepeats.asInt() : 0;
+                            final float stepYaw = times > 0 ? actualRelYaw / (times + 1) : actualRelYaw;
+                            final float stepPitch = times > 0 ? relPitch / (times + 1) : relPitch;
+
+                            if (NMSHandler.getVersion().isAtLeast(NMSVersion.v1_19)) {
+                                NetworkInterceptHelper.enable();
+                                NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
+                            } else {
+                                PaperAPITools.instance.teleport(player, playerTeleDest, PlayerTeleportEvent.TeleportCause.PLUGIN, null, Arrays.asList(TeleportCommand.Relative.values()));
+                            }
+
+                            if (offthreadRepeats != null) {
+                                NetworkInterceptHelper.enable();
+                                int ms = 50 / (times + 1);
+                                DenizenCore.runAsync(() -> {
+                                    try {
+                                        for (int i = 0; i < times; i++) {
+                                            Thread.sleep(ms);
+                                            NMSHandler.packetHelper.sendRelativeLookPacket(player, stepYaw, stepPitch);
+                                        }
+                                    } catch (Throwable ex) {
+                                        Debug.echoError(ex);
                                     }
-                                }
-                                catch (Throwable ex) {
-                                    Debug.echoError(ex);
-                                }
-                            });
+                                });
+                            }
                         }
+                    } else {
+                        NMSHandler.entityHelper.rotate(bukkitEntity, yawRaw, pitchRaw);
                     }
-                    else {
-                        NMSHandler.entityHelper.rotate(entity.getBukkitEntity(), yawRaw, pitchRaw);
+                }
+
+                if (vehicle != null) {
+                    Location vLoc = vehicle.getLocation().clone();
+                    if (loc != null) {
+                        org.bukkit.util.Vector dir = loc.toVector().subtract(vLoc.toVector());
+                        if (dir.lengthSquared() > 0) {
+                            vLoc.setDirection(dir);
+                        }
+                    } else {
+                        vLoc.setYaw(yawRaw);
+                        vLoc.setPitch(pitchRaw);
                     }
+                    
+                    vehicle.teleport(vLoc, PlayerTeleportEvent.TeleportCause.PLUGIN);
+
+                    org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                        if (vehicle.isValid() && bukkitEntity.isValid()) {
+                            vehicle.addPassenger(bukkitEntity);
+                        }
+                    });
                 }
             }
         }
@@ -174,6 +207,7 @@ public class LookCommand extends AbstractCommand {
             for (EntityTag entity : entities) {
                 BukkitRunnable task = new BukkitRunnable() {
                     long bounces = 0;
+
                     public void run() {
                         bounces++;
                         if (bounces > duration.getTicks()) {
@@ -182,11 +216,19 @@ public class LookCommand extends AbstractCommand {
                             return;
                         }
                         if (entity.isSpawned()) {
+                            org.bukkit.entity.Entity target = entity.getBukkitEntity();
+                            org.bukkit.entity.Entity vehicle = target.getVehicle();
+
                             if (loc != null) {
-                                NMSHandler.entityHelper.faceLocation(entity.getBukkitEntity(), loc);
-                            }
-                            else {
-                                NMSHandler.entityHelper.rotate(entity.getBukkitEntity(), yawRaw, pitchRaw);
+                                NMSHandler.entityHelper.faceLocation(target, loc);
+                                if (vehicle != null) {
+                                    NMSHandler.entityHelper.faceLocation(vehicle, loc);
+                                }
+                            } else {
+                                NMSHandler.entityHelper.rotate(target, yawRaw, pitchRaw);
+                                if (vehicle != null) {
+                                    NMSHandler.entityHelper.rotate(vehicle, yawRaw, pitchRaw);
+                                }
                             }
                         }
                     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
@@ -161,7 +161,6 @@ public class TeleportCommand extends AbstractCommand {
             if (vehicle != null) {
                 bukkitEntity.leaveVehicle();
             }
-
             if (entity.isFake && entity.getWorld().equals(location.getWorld())) {
                 NMSHandler.entityHelper.snapPositionTo(bukkitEntity, location.toVector());
                 NMSHandler.entityHelper.look(bukkitEntity, location.getYaw(), location.getPitch());
@@ -204,7 +203,6 @@ public class TeleportCommand extends AbstractCommand {
                 }
                 List<Relative> finalRelativeAxes = relativeAxes;
                 NMSHandler.packetHelper.sendRelativePositionPacket(player, x, y, z, yaw, pitch, finalRelativeAxes);
-
                 if (vehicle != null) {
                     vehicle.teleport(location, cause);
                     Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
@@ -213,7 +211,6 @@ public class TeleportCommand extends AbstractCommand {
                         }
                     });
                 }
-
                 DenizenCore.runAsync(() -> {
                     try {
                         for (int i = 0; i < times - 1; i++) {

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
@@ -1,5 +1,6 @@
 package com.denizenscript.denizen.scripts.commands.entity;
 
+import com.denizenscript.denizen.Denizen;
 import com.denizenscript.denizen.nms.NMSHandler;
 import com.denizenscript.denizen.objects.EntityTag;
 import com.denizenscript.denizen.objects.LocationTag;
@@ -19,6 +20,8 @@ import com.denizenscript.denizencore.scripts.commands.generator.*;
 import com.denizenscript.denizencore.utilities.Deprecations;
 import com.denizenscript.denizencore.utilities.debugging.Debug;
 import net.citizensnpcs.trait.CurrentLocation;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.util.Vector;
@@ -153,8 +156,8 @@ public class TeleportCommand extends AbstractCommand {
                 Debug.echoError("Cannot interpret object '" + entityObj + "' as an EntityTag.");
                 continue;
             }
-            org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
-            org.bukkit.entity.Entity vehicle = bukkitEntity.getVehicle();
+            Entity bukkitEntity = entity.getBukkitEntity();
+            Entity vehicle = bukkitEntity.getVehicle();
             if (vehicle != null) {
                 bukkitEntity.leaveVehicle();
             }
@@ -164,7 +167,7 @@ public class TeleportCommand extends AbstractCommand {
                 NMSHandler.entityHelper.look(bukkitEntity, location.getYaw(), location.getPitch());
                 if (vehicle != null) {
                     vehicle.teleport(location, cause);
-                    org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                    Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
                         if (vehicle.isValid() && bukkitEntity.isValid()) {
                             vehicle.addPassenger(bukkitEntity);
                         }
@@ -204,7 +207,7 @@ public class TeleportCommand extends AbstractCommand {
 
                 if (vehicle != null) {
                     vehicle.teleport(location, cause);
-                    org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                    Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
                         if (vehicle.isValid() && bukkitEntity.isValid()) {
                             vehicle.addPassenger(bukkitEntity);
                         }
@@ -233,7 +236,7 @@ public class TeleportCommand extends AbstractCommand {
 
             if (vehicle != null) {
                 vehicle.teleport(location, cause);
-                org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                Bukkit.getScheduler().runTask(Denizen.getInstance(), () -> {
                     if (vehicle.isValid() && bukkitEntity.isValid()) {
                         vehicle.addPassenger(bukkitEntity);
                     }

--- a/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/scripts/commands/entity/TeleportCommand.java
@@ -153,9 +153,23 @@ public class TeleportCommand extends AbstractCommand {
                 Debug.echoError("Cannot interpret object '" + entityObj + "' as an EntityTag.");
                 continue;
             }
+            org.bukkit.entity.Entity bukkitEntity = entity.getBukkitEntity();
+            org.bukkit.entity.Entity vehicle = bukkitEntity.getVehicle();
+            if (vehicle != null) {
+                bukkitEntity.leaveVehicle();
+            }
+
             if (entity.isFake && entity.getWorld().equals(location.getWorld())) {
-                NMSHandler.entityHelper.snapPositionTo(entity.getBukkitEntity(), location.toVector());
-                NMSHandler.entityHelper.look(entity.getBukkitEntity(), location.getYaw(), location.getPitch());
+                NMSHandler.entityHelper.snapPositionTo(bukkitEntity, location.toVector());
+                NMSHandler.entityHelper.look(bukkitEntity, location.getYaw(), location.getPitch());
+                if (vehicle != null) {
+                    vehicle.teleport(location, cause);
+                    org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                        if (vehicle.isValid() && bukkitEntity.isValid()) {
+                            vehicle.addPassenger(bukkitEntity);
+                        }
+                    });
+                }
                 return;
             }
             if (offthreadRepeats != null && relativeAxes != null && entity.isPlayer()) {
@@ -187,6 +201,16 @@ public class TeleportCommand extends AbstractCommand {
                 }
                 List<Relative> finalRelativeAxes = relativeAxes;
                 NMSHandler.packetHelper.sendRelativePositionPacket(player, x, y, z, yaw, pitch, finalRelativeAxes);
+
+                if (vehicle != null) {
+                    vehicle.teleport(location, cause);
+                    org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                        if (vehicle.isValid() && bukkitEntity.isValid()) {
+                            vehicle.addPassenger(bukkitEntity);
+                        }
+                    });
+                }
+
                 DenizenCore.runAsync(() -> {
                     try {
                         for (int i = 0; i < times - 1; i++) {
@@ -201,10 +225,20 @@ public class TeleportCommand extends AbstractCommand {
                 continue;
             }
             if (entityOptions != null || relativeAxes != null) {
-                PaperAPITools.instance.teleport(entity.getBukkitEntity(), location, cause, entityOptions, relativeAxes);
-                continue;
+                PaperAPITools.instance.teleport(bukkitEntity, location, cause, entityOptions, relativeAxes);
             }
-            entity.teleport(location, cause);
+            else {
+                entity.teleport(location, cause);
+            }
+
+            if (vehicle != null) {
+                vehicle.teleport(location, cause);
+                org.bukkit.Bukkit.getScheduler().runTask(com.denizenscript.denizen.Denizen.getInstance(), () -> {
+                    if (vehicle.isValid() && bukkitEntity.isValid()) {
+                        vehicle.addPassenger(bukkitEntity);
+                    }
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
This update resolves two distinct issues with the look command:

## Problem
- The `offthread_repeat` argument applied the total relative yaw and pitch repeatedly instead of splitting them into fractional step increments
- Paper pull request https://github.com/PaperMC/Paper/pull/13181 deprecated `RETAIN_VEHICLE` and tightened teleport and rotation restrictions, causing mounted entities and players to fail look updates

## Solution
- fixed the sub-tick step calculation so that `offthread_repeat` splits the relative yaw and pitch into fractional step increments instead of repeatedly applying the total distance
- resolved client-side packet drops and Paper vehicle restrictions by temporarily unmounting entities during rotation updates and remounting them properly

## Testing, References:
- working build: [Denizen-1.91.0-SNAPSHOT.jar](http://panel.behr.dev/builds/Denizen-1.91.0-SNAPSHOT.jar)
- fixed debug log: https://paste.denizenscript.com/View/141021
- [demonstration clip](https://cdn.discordapp.com/attachments/1440243723303915600/1529417897699704873/20260722-0919-19.4475242.mp4?ex=6a61dcea&is=6a608b6a&hm=5729f3ee20e103f886e493ac2143c10d389acbb513fb2ced99ad76c5f15addef)
- [relevant thread](https://discord.com/channels/315163488085475337/1440243723303915600)