### PR TITLE
`item despawns` event: Prevent multimatching with EntityDespawns event

### DIFF
--- a/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityDespawnScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/entity/EntityDespawnScriptEvent.java
@@ -34,7 +34,7 @@ public class EntityDespawnScriptEvent extends BukkitScriptEvent {
     public EntityDespawnScriptEvent() {
         instance = this;
         registerCouldMatcher("<entity> despawns");
-        registerSwitches("cause");
+        registerSwitches("cause", "entity");
     }
 
     public static EntityDespawnScriptEvent instance;
@@ -51,6 +51,9 @@ public class EntityDespawnScriptEvent extends BukkitScriptEvent {
             return false;
         }
         if (!runInCheck(path, entity.getLocation())) {
+            return false;
+        }
+        if (!path.tryObjectSwitch("entity", entity)) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/item/ItemDespawnsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/item/ItemDespawnsScriptEvent.java
@@ -32,7 +32,7 @@ public class ItemDespawnsScriptEvent extends BukkitScriptEvent implements Listen
 
     public ItemDespawnsScriptEvent() {
         registerCouldMatcher("<item> despawns");
-        registerSwitches("type");
+        registerSwitches("item");
     }
 
     public ItemTag item;
@@ -48,7 +48,7 @@ public class ItemDespawnsScriptEvent extends BukkitScriptEvent implements Listen
         if (!runInCheck(path, location)) {
             return false;
         }
-        if (!path.tryObjectSwitch("type", item)) {
+        if (!path.tryObjectSwitch("item", item)) {
             return false;
         }
         return super.matches(path);

--- a/plugin/src/main/java/com/denizenscript/denizen/events/item/ItemDespawnsScriptEvent.java
+++ b/plugin/src/main/java/com/denizenscript/denizen/events/item/ItemDespawnsScriptEvent.java
@@ -32,6 +32,7 @@ public class ItemDespawnsScriptEvent extends BukkitScriptEvent implements Listen
 
     public ItemDespawnsScriptEvent() {
         registerCouldMatcher("<item> despawns");
+        registerSwitches("type");
     }
 
     public ItemTag item;
@@ -47,17 +48,20 @@ public class ItemDespawnsScriptEvent extends BukkitScriptEvent implements Listen
         if (!runInCheck(path, location)) {
             return false;
         }
+        if (!path.tryObjectSwitch("type", item)) {
+            return false;
+        }
         return super.matches(path);
     }
 
     @Override
     public ObjectTag getContext(String name) {
-        switch (name) {
-            case "location": return location;
-            case "item": return item;
-            case "entity": return entity;
-        }
-        return super.getContext(name);
+        return switch (name) {
+            case "location" -> location;
+            case "item" -> item;
+            case "entity" -> entity;
+            default -> super.getContext(name);
+        };
     }
 
     @EventHandler


### PR DESCRIPTION
This PR fixes an issue where the `item despawns` event could be matched with the `entity despawns` event. The issue was reported by [Talfein on Discord ](https://discord.com/channels/315163488085475337/1537232459492761690/1537232459492761690)and is resolved by adding entity/item switches.

The solution to prevent multimatching when using a "catch-all" is:

```denizenscript
item_match:
    type: world
    events:
        on item despawns item:item:
        - announce "<context.item> despawned."
entity_match:
    type: world
    events:
        on entity despawns entity:entity:
        - announce "<context.entity> despawned due <context.cause>."
```